### PR TITLE
Add If-Match header config & test for ETag headers

### DIFF
--- a/ProcessesApi.Tests/V1/E2ETests/GetByIdEndToEndTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/GetByIdEndToEndTests.cs
@@ -2,10 +2,12 @@ using AutoFixture;
 using FluentAssertions;
 using Hackney.Core.Testing.DynamoDb;
 using Newtonsoft.Json;
+using ProcessesApi.V1.Boundary.Constants;
 using ProcessesApi.V1.Boundary.Response;
 using ProcessesApi.V1.Domain;
 using ProcessesApi.V1.Factories;
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -55,7 +57,7 @@ namespace ProcessesApi.Tests.V1.E2ETests
         }
 
         [Fact]
-        public async Task GetProcessByValidIdReturnsOKResponse()
+        public async Task GetProcessByValidIdReturnsOKResponseWithETagHeaders()
         {
             // Arrange
             var entity = ConstructTestEntity();
@@ -72,6 +74,11 @@ namespace ProcessesApi.Tests.V1.E2ETests
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             apiEntity.Should().BeEquivalentTo(entity, config => config.Excluding(y => y.VersionNumber));
 
+            var expectedEtagValue = $"\"{0}\"";
+            response.Headers.ETag.Tag.Should().Be(expectedEtagValue);
+            var eTagHeaders = response.Headers.GetValues(HeaderConstants.ETag);
+            eTagHeaders.Count().Should().Be(1);
+            eTagHeaders.First().Should().Be(expectedEtagValue);
         }
 
         [Fact]

--- a/ProcessesApi/Startup.cs
+++ b/ProcessesApi/Startup.cs
@@ -181,7 +181,7 @@ namespace ProcessesApi
                   .AllowAnyOrigin()
                   .AllowAnyHeader()
                   .AllowAnyMethod()
-                  .WithExposedHeaders("ETag", "x-correlation-id"));
+                  .WithExposedHeaders("ETag", "If-Match", "x-correlation-id"));
 
 
             if (env.IsDevelopment())

--- a/ProcessesApi/serverless.yml
+++ b/ProcessesApi/serverless.yml
@@ -38,6 +38,7 @@ functions:
               - X-Amz-Security-Token
               - X-Amz-User-Agent
               - x-correlation-id
+              - If-Match
             allowCredentials: false
       - http:
           path: /swagger/{proxy+}


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

The PATCH endpoint isn't handling the If-Match headers correctly in the Dev environment.

### *What changes have we introduced*

- Add `If-Match` to the serverless.yml and startup files
- Update GET Process by ID E2E tests to check E-Tag header

#### _Checklist_

- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
