### PR TITLE
Mttl 2041

### DIFF
--- a/ProcessesApi.Tests/V1/Boundary/Validation/CreateProcessQueryValidatorTests.cs
+++ b/ProcessesApi.Tests/V1/Boundary/Validation/CreateProcessQueryValidatorTests.cs
@@ -50,6 +50,17 @@ namespace ProcessesApi.Tests.V1.Boundary.Validation
         }
 
         [Fact]
+        public void RequestShouldErrorWithNullRelatedEntity()
+        {
+            //Arrange
+            var query = new CreateProcess() {  };
+            //Act
+            var result = _classUnderTest.TestValidate(query);
+            //Assert
+            result.ShouldHaveValidationErrorFor(x => x.RelatedEntities);
+        }
+
+        [Fact]
         public void RequestShouldErrorWithEmptyDocumentIDs()
         {
             //Arrange

--- a/ProcessesApi.Tests/V1/Boundary/Validation/CreateProcessQueryValidatorTests.cs
+++ b/ProcessesApi.Tests/V1/Boundary/Validation/CreateProcessQueryValidatorTests.cs
@@ -53,7 +53,7 @@ namespace ProcessesApi.Tests.V1.Boundary.Validation
         public void RequestShouldErrorWithNullRelatedEntity()
         {
             //Arrange
-            var query = new CreateProcess() {  };
+            var query = new CreateProcess() { };
             //Act
             var result = _classUnderTest.TestValidate(query);
             //Assert

--- a/ProcessesApi/V1/Boundary/Request/Validation/CreateProcessQueryValidator.cs
+++ b/ProcessesApi/V1/Boundary/Request/Validation/CreateProcessQueryValidator.cs
@@ -9,7 +9,8 @@ namespace ProcessesApi.V1.Boundary.Request.Validation
         {
             RuleFor(x => x.TargetId).NotNull()
                             .NotEqual(Guid.Empty);
-            RuleFor(x => x.RelatedEntities).NotNull();
+            // Uncomment when frontend has added relatedEntities as part of the CreateProcess Request
+            //RuleFor(x => x.RelatedEntities).NotNull();
             RuleForEach(x => x.RelatedEntities)
                             .NotEqual(Guid.Empty);
             RuleForEach(x => x.Documents).NotNull()

--- a/ProcessesApi/V1/Boundary/Request/Validation/CreateProcessQueryValidator.cs
+++ b/ProcessesApi/V1/Boundary/Request/Validation/CreateProcessQueryValidator.cs
@@ -9,7 +9,8 @@ namespace ProcessesApi.V1.Boundary.Request.Validation
         {
             RuleFor(x => x.TargetId).NotNull()
                             .NotEqual(Guid.Empty);
-            RuleForEach(x => x.RelatedEntities).NotNull()
+            RuleFor(x => x.RelatedEntities).NotNull();
+            RuleForEach(x => x.RelatedEntities)
                             .NotEqual(Guid.Empty);
             RuleForEach(x => x.Documents).NotNull()
                             .NotEqual(Guid.Empty);

--- a/ProcessesApi/V1/UseCase/SoleToJointService.cs
+++ b/ProcessesApi/V1/UseCase/SoleToJointService.cs
@@ -3,6 +3,7 @@ using ProcessesApi.V1.Helper;
 using ProcessesApi.V1.UseCase.Interfaces;
 using Stateless;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -29,6 +30,10 @@ namespace ProcessesApi.V1.UseCase
 
         private void AddIncomingTenantId(UpdateProcessState processRequest)
         {
+            //TOD: When doing a POST request from the FE they should created a relatedEntities object with all neccesary values
+            //Once Frontend work is completed the IF statement below should be removed.
+            if (_soleToJointProcess.RelatedEntities == null)
+                _soleToJointProcess.RelatedEntities = new List<Guid>();
             _soleToJointProcess.RelatedEntities.Add(Guid.Parse(processRequest.FormData["incomingTenantId"].ToString()));
         }
 


### PR DESCRIPTION
Workaround to solve issues with the FE interacting with the API

Currently, when the FE does a POST request it doesn't pass through the related Entities object hence the object is null, to temporarily work around this we have updated the API to create a new list when the object is null