### PR TITLE
Fix SonarCloud scan of C#

### DIFF
--- a/ProcessesApi.Tests/Dockerfile
+++ b/ProcessesApi.Tests/Dockerfile
@@ -36,6 +36,8 @@ RUN dotnet restore ./ProcessesApi.Tests/ProcessesApi.Tests.csproj
 # Copy everything else and build
 COPY . .
 
+RUN dotnet build -c Release -o out ProcessesApi/ProcessesApi.csproj
 RUN dotnet build -c debug -o out ProcessesApi.Tests/ProcessesApi.Tests.csproj
 
 CMD dotnet test
+RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"


### PR DESCRIPTION
Current scan does not send a report for C# files to SonarCloud - changes to try and fix that.