### PR TITLE
Mttl 2835 - Implement CloseProcess trigger 

### DIFF
--- a/ProcessesApi.Tests/AwsMockWebApplicationFactory.cs
+++ b/ProcessesApi.Tests/AwsMockWebApplicationFactory.cs
@@ -59,12 +59,9 @@ namespace ProcessesApi.Tests
         {
             if (disposing && !_disposed)
             {
-                if (null != DynamoDbFixture)
-                    DynamoDbFixture.Dispose();
-                if (null != SnsFixture)
-                    SnsFixture.Dispose();
-                if (null != Client)
-                    Client.Dispose();
+                DynamoDbFixture?.Dispose();
+                SnsFixture?.Dispose();
+                Client?.Dispose();
                 _disposed = true;
             }
         }
@@ -93,7 +90,7 @@ namespace ProcessesApi.Tests
                 DynamoDbFixture.EnsureTablesExist(_tables);
 
                 SnsFixture = serviceProvider.GetRequiredService<ISnsFixture>();
-                SnsFixture.CreateSnsTopic<EntityEventSns>("processes", "PROCESS_SNS_ARN");
+                SnsFixture.CreateSnsTopic<EntityEventSns>("processes.fifo", "PROCESS_SNS_ARN");
             });
         }
     }

--- a/ProcessesApi.Tests/ProcessesApi.Tests.csproj
+++ b/ProcessesApi.Tests/ProcessesApi.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
-    <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0-feat-update-sns-0002" />
+    <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0-feat-update-sns-0003" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/ProcessesApi.Tests/ProcessesApi.Tests.csproj
+++ b/ProcessesApi.Tests/ProcessesApi.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
-    <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.58.0" />
+    <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0-feat-update-sns-0002" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/ProcessesApi.Tests/ProcessesApi.Tests.csproj
+++ b/ProcessesApi.Tests/ProcessesApi.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
-    <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0-feat-update-sns-0003" />
+    <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0-feat-update-sns-0005" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/ProcessesApi.Tests/ProcessesApi.Tests.csproj
+++ b/ProcessesApi.Tests/ProcessesApi.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
-    <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
+    <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0-feat-update-sns-0005" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/ProcessesApi.Tests/ProcessesApi.Tests.csproj
+++ b/ProcessesApi.Tests/ProcessesApi.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.66.0" />
-    <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0-feat-update-sns-0005" />
+    <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Amazon.DynamoDBv2.DataModel;
 using Amazon.SimpleNotificationService;
-using Amazon.SimpleNotificationService.Model;
 using AutoFixture;
 using ProcessesApi.V1.Boundary.Request;
 using ProcessesApi.V1.Domain;
@@ -211,15 +210,17 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
 
         public void GivenAnUpdateProcessByIdRequestWithValidationErrors()
         {
-            GivenAnUpdateProcessByIdRequest(ProcessId);
+            GivenAnUpdateProcessByIdRequest();
             UpdateProcessByIdRequestObject.ProcessData.Documents.Add(Guid.Empty);
         }
-        public void GivenAnUpdateProcessByIdRequest(Guid id)
+
+        public void GivenAnUpdateProcessByIdRequest()
         {
-            UpdateProcessByIdRequest = _fixture.Build<ProcessQuery>()
-                                           .With(x => x.ProcessName, ProcessName.soletojoint)
-                                           .With(x => x.Id, id)
-                                           .Create();
+            UpdateProcessByIdRequest = new ProcessQuery
+            {
+                ProcessName = ProcessName.soletojoint,
+                Id = ProcessId
+            };
             UpdateProcessByIdRequestObject = _fixture.Create<UpdateProcessByIdRequestObject>();
         }
     }

--- a/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -88,7 +88,6 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
         {
             CreateProcessRequest = _fixture.Build<CreateProcess>()
                                 .Create();
-            CreateSnsTopic();
             ProcessName = ProcessName.soletojoint;
         }
 
@@ -97,7 +96,6 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
             CreateProcessRequest = _fixture.Build<CreateProcess>()
                             .With(x => x.TargetId, Guid.Empty)
                             .Create();
-            CreateSnsTopic();
             ProcessName = ProcessName.soletojoint;
         }
 
@@ -115,6 +113,7 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
         public void GivenACloseProcessRequest()
         {
             GivenAnUpdateSoleToJointProcessRequest(SoleToJointPermittedTriggers.CloseProcess);
+            UpdateProcessRequestObject.FormData.Add(SoleToJointFormDataKeys.HasNotifiedResident, true);
         }
 
         public void GivenACheckAutomatedEligibilityRequest()
@@ -222,21 +221,6 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
                                            .With(x => x.Id, id)
                                            .Create();
             UpdateProcessByIdRequestObject = _fixture.Create<UpdateProcessByIdRequestObject>();
-        }
-
-        private void CreateSnsTopic()
-        {
-            var snsAttrs = new Dictionary<string, string>();
-            snsAttrs.Add("fifo_topic", "true");
-            snsAttrs.Add("content_based_deduplication", "true");
-
-            var response = _amazonSimpleNotificationService.CreateTopicAsync(new CreateTopicRequest
-            {
-                Name = "processes",
-                Attributes = snsAttrs
-            }).Result;
-
-            Environment.SetEnvironmentVariable("PROCESS_SNS_ARN", response.TopicArn);
         }
     }
 }

--- a/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -112,6 +112,11 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
             UpdateProcessRequestObject = _fixture.Create<UpdateProcessRequestObject>();
         }
 
+        public void GivenACloseProcessRequest()
+        {
+            GivenAnUpdateSoleToJointProcessRequest(SoleToJointPermittedTriggers.CloseProcess);
+        }
+
         public void GivenACheckAutomatedEligibilityRequest()
         {
             GivenAnUpdateSoleToJointProcessRequest(SoleToJointPermittedTriggers.CheckAutomatedEligibility);

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/CreateNewSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/CreateNewSoleToJointProcessSteps.cs
@@ -65,6 +65,9 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             dbRecord.CurrentState.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, 2000);
 
             dbRecord.PreviousStates.Should().BeEmpty();
+
+            // Cleanup
+            await _dbFixture.DynamoDbContext.DeleteAsync<ProcessesDb>(dbRecord.Id).ConfigureAwait(false);
         }
 
         public async Task ThenProcessStartedEventIsRaised(ProcessFixture processFixture, ISnsFixture snsFixture)

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/CreateNewSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/CreateNewSoleToJointProcessSteps.cs
@@ -84,6 +84,7 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
                 var expected = dbRecord.ToDomain();
                 var actualNewData = JsonConvert.DeserializeObject<Process>(actual.EventData.NewData.ToString());
                 actualNewData.Should().BeEquivalentTo(expected);
+                
                 actual.EventData.OldData.Should().BeNull();
 
                 actual.EventType.Should().Be(ProcessStartedEventConstants.EVENTTYPE);
@@ -99,10 +100,6 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             var snsResult = await snsVerifier.VerifySnsEventRaised(verifyFunc);
 
             if (!snsResult && snsVerifier.LastException != null) throw snsVerifier.LastException;
-            await snsVerifier.PurgeQueueMessages().ConfigureAwait(false);
-
-            // Cleanup
-            await _dbFixture.DynamoDbContext.DeleteAsync<ProcessesDb>(dbRecord.Id).ConfigureAwait(false);
         }
 
         public void ThenBadRequestIsReturned()

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/CreateNewSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/CreateNewSoleToJointProcessSteps.cs
@@ -83,8 +83,9 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
 
                 var expected = dbRecord.ToDomain();
                 var actualNewData = JsonConvert.DeserializeObject<Process>(actual.EventData.NewData.ToString());
-                actualNewData.Should().BeEquivalentTo(expected);
-                
+                actualNewData.Should().BeEquivalentTo(expected, c => c.Excluding(x => x.CurrentState)
+                                                                      .Excluding(x => x.VersionNumber));
+
                 actual.EventData.OldData.Should().BeNull();
 
                 actual.EventType.Should().Be(ProcessStartedEventConstants.EVENTTYPE);

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateProcessByIdSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateProcessByIdSteps.cs
@@ -78,6 +78,7 @@ namespace ProcessesApi.Tests.V1.E2ETests.Steps
             var snsResult = await snsVerifier.VerifySnsEventRaised(verifyFunc);
 
             if (!snsResult && snsVerifier.LastException != null) throw snsVerifier.LastException;
+            await snsVerifier.PurgeQueueMessages().ConfigureAwait(false);
         }
 
         public void ThenNotFoundIsReturned()

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateProcessByIdSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateProcessByIdSteps.cs
@@ -3,7 +3,6 @@ using Hackney.Core.Sns;
 using Hackney.Core.Testing.DynamoDb;
 using Hackney.Core.Testing.Shared.E2E;
 using Hackney.Core.Testing.Sns;
-using Newtonsoft.Json;
 using ProcessesApi.Tests.V1.E2E.Fixtures;
 using ProcessesApi.Tests.V1.E2ETests.Steps.Constants;
 using ProcessesApi.V1.Boundary.Constants;
@@ -36,7 +35,7 @@ namespace ProcessesApi.Tests.V1.E2ETests.Steps
             var uri = new Uri($"api/v1/process/{request.ProcessName}/{request.Id}", UriKind.Relative);
             var message = new HttpRequestMessage(HttpMethod.Patch, uri);
 
-            message.Content = new StringContent(JsonConvert.SerializeObject(requestObject), Encoding.UTF8, "application/json");
+            message.Content = new StringContent(JsonSerializer.Serialize(requestObject, _jsonOptions), Encoding.UTF8, "application/json");
             message.Headers.Add("Authorization", token);
             message.Headers.TryAddWithoutValidation(HeaderConstants.IfMatch, $"\"{ifMatch}\"");
             message.Method = HttpMethod.Patch;
@@ -50,9 +49,14 @@ namespace ProcessesApi.Tests.V1.E2ETests.Steps
 
             Action<string, ProcessesDb> verifyData = (dataAsString, process) =>
             {
-                var dataDic = JsonSerializer.Deserialize<Dictionary<string, object>>(dataAsString, CreateJsonOptions());
-                dataDic["processData"].Should().Be(process.CurrentState.ProcessData);
-                dataDic["assignment"].Should().Be(process.CurrentState.Assignment);
+                var dataDic = JsonSerializer.Deserialize<Dictionary<string, object>>(dataAsString, _jsonOptions);
+
+                var assignment = JsonSerializer.Deserialize<Assignment>(dataDic["assignment"].ToString(), _jsonOptions);
+                assignment.Should().BeEquivalentTo(process.CurrentState.Assignment);
+
+                var processData = JsonSerializer.Deserialize<ProcessData>(dataDic["processData"].ToString(), _jsonOptions);
+                processData.Documents.Should().BeEquivalentTo(process.CurrentState.ProcessData.Documents);
+                processData.FormData.Should().HaveSameCount(process.CurrentState.ProcessData.FormData); // workaround for validating form data
             };
 
             Action<EntityEventSns> verifyFunc = actual =>
@@ -62,8 +66,8 @@ namespace ProcessesApi.Tests.V1.E2ETests.Steps
                 actual.DateTime.Should().BeCloseTo(DateTime.UtcNow, 2000);
                 actual.EntityId.Should().Be(processFixture.ProcessId);
 
-                verifyData((actual.EventData.OldData as string), processFixture.Process.ToDatabase());
-                verifyData((actual.EventData.NewData as string), dbEntity);
+                verifyData(actual.EventData.OldData.ToString(), processFixture.Process.ToDatabase());
+                verifyData(actual.EventData.NewData.ToString(), dbEntity);
 
                 actual.EventType.Should().Be(ProcessUpdatedEventConstants.EVENTTYPE);
                 actual.SourceDomain.Should().Be(ProcessUpdatedEventConstants.SOURCE_DOMAIN);

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateProcessByIdSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateProcessByIdSteps.cs
@@ -78,7 +78,6 @@ namespace ProcessesApi.Tests.V1.E2ETests.Steps
             var snsResult = await snsVerifier.VerifySnsEventRaised(verifyFunc);
 
             if (!snsResult && snsVerifier.LastException != null) throw snsVerifier.LastException;
-            await snsVerifier.PurgeQueueMessages().ConfigureAwait(false);
         }
 
         public void ThenNotFoundIsReturned()

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
@@ -153,7 +153,6 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             var snsResult = await snsVerifier.VerifySnsEventRaised(verifyFunc);
 
             if (!snsResult && snsVerifier.LastException != null) throw snsVerifier.LastException;
-            await snsVerifier.PurgeQueueMessages().ConfigureAwait(false);
         }
 
         public async Task ThenTheProcessUpdatedEventIsRaised(ISnsFixture snsFixture, Guid processId)
@@ -180,8 +179,8 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             var snsVerifier = snsFixture.GetSnsEventVerifier<EntityEventSns>();
             var snsResult = await snsVerifier.VerifySnsEventRaised(verifyFunc);
 
+            // Console.WriteLine($"Number of SQS messages: {snsVerifier.NumberOfMessages}");
             if (!snsResult && snsVerifier.LastException != null) throw snsVerifier.LastException;
-            await snsVerifier.PurgeQueueMessages().ConfigureAwait(false);
         }
 
         private async Task CheckProcessState(Guid processId, string currentState, string previousState)
@@ -190,9 +189,6 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
 
             dbRecord.CurrentState.State.Should().Be(currentState);
             dbRecord.PreviousStates.Last().State.Should().Be(previousState);
-
-            // Cleanup
-            await _dbFixture.DynamoDbContext.DeleteAsync<ProcessesDb>(dbRecord.Id).ConfigureAwait(false);
         }
     }
 }

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
@@ -93,7 +93,7 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
 
         public async Task ThenTheProcessStateIsUpdatedToProcessClosed(UpdateProcessQuery request, string previousState)
         {
-            await CheckProcessState(request.Id, SoleToJointStates.ProcessClosed, previousState).ConfigureAwait(false);
+            await CheckProcessState(request.Id, SharedProcessStates.ProcessClosed, previousState).ConfigureAwait(false);
         }
 
         public async Task ThenTheProcessStateIsUpdatedToAutomatedEligibilityChecksPassed(UpdateProcessQuery request)

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
@@ -206,7 +206,6 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             {
                 var dataDic = JsonSerializer.Deserialize<Dictionary<string, object>>(dataAsString, _jsonOptions);
                 dataDic.Should().ContainKey("description");
-                DateTime.Parse(dataDic["description"].ToString());
             };
 
             Action<EntityEventSns> verifyFunc = actual =>

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
@@ -13,9 +13,9 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Hackney.Core.Sns;
-using Hackney.Core.Testing.Sns;
 using ProcessesApi.Tests.V1.E2ETests.Steps.Constants;
 using ProcessesApi.V1.Infrastructure.JWT;
+using Hackney.Core.Testing.Sns;
 
 namespace ProcessesApi.Tests.V1.E2E.Steps
 {
@@ -153,6 +153,7 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             var snsResult = await snsVerifier.VerifySnsEventRaised(verifyFunc);
 
             if (!snsResult && snsVerifier.LastException != null) throw snsVerifier.LastException;
+            await snsVerifier.PurgeQueueMessages().ConfigureAwait(false);
         }
 
         public async Task ThenTheProcessUpdatedEventIsRaised(ISnsFixture snsFixture, Guid processId)
@@ -180,6 +181,7 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             var snsResult = await snsVerifier.VerifySnsEventRaised(verifyFunc);
 
             if (!snsResult && snsVerifier.LastException != null) throw snsVerifier.LastException;
+            await snsVerifier.PurgeQueueMessages().ConfigureAwait(false);
         }
 
         private async Task CheckProcessState(Guid processId, string currentState, string previousState)

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
@@ -179,7 +179,6 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             var snsVerifier = snsFixture.GetSnsEventVerifier<EntityEventSns>();
             var snsResult = await snsVerifier.VerifySnsEventRaised(verifyFunc);
 
-            // Console.WriteLine($"Number of SQS messages: {snsVerifier.NumberOfMessages}");
             if (!snsResult && snsVerifier.LastException != null) throw snsVerifier.LastException;
         }
 
@@ -189,6 +188,9 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
 
             dbRecord.CurrentState.State.Should().Be(currentState);
             dbRecord.PreviousStates.Last().State.Should().Be(previousState);
+
+            // Cleanup
+            await _dbFixture.DynamoDbContext.DeleteAsync<ProcessesDb>(processId).ConfigureAwait(false);
         }
     }
 }

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
@@ -88,6 +88,11 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             dbRecord.RelatedEntities.Should().Contain(incomingTenantId);
         }
 
+        public async Task ThenTheProcessStateIsUpdatedToProcessClosed(UpdateProcessQuery request, string previousState)
+        {
+            await CheckProcessState(request.Id, SoleToJointStates.ProcessClosed, previousState).ConfigureAwait(false);
+        }
+
         public async Task ThenTheProcessStateIsUpdatedToAutomatedEligibilityChecksPassed(UpdateProcessQuery request)
         {
             await CheckProcessState(request.Id, SoleToJointStates.AutomatedChecksPassed, SoleToJointStates.SelectTenants).ConfigureAwait(false);

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/CreateNewProcessTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/CreateNewProcessTests.cs
@@ -41,7 +41,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
             {
                 _processFixture?.Dispose();
                 _snsFixture?.PurgeAllQueueMessages();
-                
+
                 _disposed = true;
             }
         }

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/CreateNewProcessTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/CreateNewProcessTests.cs
@@ -39,9 +39,9 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         {
             if (disposing && !_disposed)
             {
-                if (_processFixture != null)
-                    _processFixture.Dispose();
-
+                _processFixture?.Dispose();
+                _snsFixture?.PurgeAllQueueMessages();
+                
                 _disposed = true;
             }
         }

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/CreateNewProcessTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/CreateNewProcessTests.cs
@@ -52,7 +52,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
             this.Given(g => _processFixture.GivenANewSoleToJointProcessRequest())
                 .When(w => _steps.WhenACreateProcessRequestIsMade(_processFixture.CreateProcessRequest, _processFixture.ProcessName))
                 .Then(t => _steps.ThenTheProcessIsCreated(_processFixture.CreateProcessRequest))
-                .Then(t => _steps.ThenProcessStartedEventIsRaised(_processFixture, _snsFixture))
+                    .And(t => _steps.ThenProcessStartedEventIsRaised(_processFixture, _snsFixture))
                 .BDDfy();
         }
 

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/CreateNewProcessTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/CreateNewProcessTests.cs
@@ -51,8 +51,8 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         {
             this.Given(g => _processFixture.GivenANewSoleToJointProcessRequest())
                 .When(w => _steps.WhenACreateProcessRequestIsMade(_processFixture.CreateProcessRequest, _processFixture.ProcessName))
-                .Then(t => _steps.ThenTheProcessIsCreated(_processFixture.CreateProcessRequest))
-                    .And(t => _steps.ThenProcessStartedEventIsRaised(_processFixture, _snsFixture))
+                .Then(t => _steps.ThenProcessStartedEventIsRaised(_processFixture, _snsFixture))
+                    .And(t => _steps.ThenTheProcessIsCreated(_processFixture.CreateProcessRequest))
                 .BDDfy();
         }
 

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/GetProcessByIdTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/GetProcessByIdTests.cs
@@ -40,8 +40,8 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         {
             if (disposing && !_disposed)
             {
-                if (_processFixture != null)
-                    _processFixture.Dispose();
+                _processFixture?.Dispose();
+                _snsFixture?.PurgeAllQueueMessages();
 
                 _disposed = true;
             }

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateProcessByIdTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateProcessByIdTests.cs
@@ -40,7 +40,9 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         {
             if (disposing && !_disposed)
             {
-                if (_processFixture != null) _processFixture.Dispose();
+                _processFixture?.Dispose();
+                _snsFixture?.PurgeAllQueueMessages();
+
                 _disposed = true;
             }
         }

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateProcessByIdTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateProcessByIdTests.cs
@@ -51,7 +51,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         public void UpdateProcessByIdReturnsNotFoundWhenProcessDoesNotExist()
         {
             this.Given(g => _processFixture.GivenASoleToJointProcessDoesNotExist())
-                    .And(a => _processFixture.GivenAnUpdateProcessByIdRequest(_processFixture.ProcessId))
+                    .And(a => _processFixture.GivenAnUpdateProcessByIdRequest())
                 .When(w => _steps.WhenAnUpdateProcessByIdRequestIsMade(_processFixture.UpdateProcessByIdRequest, _processFixture.UpdateProcessByIdRequestObject, 0))
                 .Then(t => _steps.ThenNotFoundIsReturned())
                 .BDDfy();
@@ -61,7 +61,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         public void UpdateProcessByIdSucceedsWhenProcessDoesExist()
         {
             this.Given(g => _processFixture.GivenASoleToJointProcessExists(SharedProcessStates.ApplicationInitialised))
-                    .And(a => _processFixture.GivenAnUpdateProcessByIdRequest(_processFixture.ProcessId))
+                    .And(a => _processFixture.GivenAnUpdateProcessByIdRequest())
                 .When(w => _steps.WhenAnUpdateProcessByIdRequestIsMade(_processFixture.UpdateProcessByIdRequest, _processFixture.UpdateProcessByIdRequestObject, 0))
                 .Then(t => _steps.ThenTheProcessDataIsUpdated(_processFixture.UpdateProcessByIdRequest, _processFixture.UpdateProcessByIdRequestObject))
                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture))
@@ -74,7 +74,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         public void ServiceReturnsConflictWhenIncorrectVersionNumber(int? versionNumber)
         {
             this.Given(g => _processFixture.GivenASoleToJointProcessExists(SharedProcessStates.ApplicationInitialised))
-                .And(a => _processFixture.GivenAnUpdateProcessByIdRequest(_processFixture.ProcessId))
+                .And(a => _processFixture.GivenAnUpdateProcessByIdRequest())
                 .When(w => _steps.WhenAnUpdateProcessByIdRequestIsMade(_processFixture.UpdateProcessByIdRequest, _processFixture.UpdateProcessByIdRequestObject, versionNumber))
                 .Then(t => _steps.ThenVersionConflictExceptionIsReturned(versionNumber))
                 .BDDfy();

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateSoleToJointProcessTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateSoleToJointProcessTests.cs
@@ -93,6 +93,22 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
                 .BDDfy();
         }
 
+        // List all states that CloseProcess can be triggered from
+        [Theory]
+        [InlineData(SoleToJointStates.AutomatedChecksFailed)]
+        [InlineData(SoleToJointStates.ManualChecksFailed)]
+        [InlineData(SoleToJointStates.BreachChecksFailed)]
+        public void ProcessStateIsUpdatedToProcessClosed(string fromState)
+        {
+            this.Given(g => _processFixture.GivenASoleToJointProcessExists(fromState))
+                    .And(a => _processFixture.GivenACloseProcessRequest())
+                .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
+                .Then(a => _steps.ThenTheProcessDataIsUpdated(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject))
+                    .And(a => _steps.ThenTheProcessStateIsUpdatedToProcessClosed(_processFixture.UpdateProcessRequest, fromState))
+                    .And(a => _steps.ThenTheProcessClosedEventIsRaised(_snsFixture, _processFixture.ProcessId))
+                .BDDfy();
+        }
+
         #region Automatic eligibility checks
 
         [Fact]
@@ -162,7 +178,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
                 .Then(a => _steps.ThenTheProcessDataIsUpdated(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject))
                     .And(a => _steps.ThenTheIncomingTenantIdIsAddedToRelatedEntities(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject))
                     .And(a => _steps.ThenTheProcessStateIsUpdatedToAutomatedEligibilityChecksFailed(_processFixture.UpdateProcessRequest))
-                    .And(a => _steps.ThenTheProcessClosedEventIsRaised(_snsFixture, _processFixture.ProcessId))
+                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture.ProcessId))
                 .BDDfy();
         }
 
@@ -189,7 +205,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
                 .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
                 .Then(a => _steps.ThenTheProcessDataIsUpdated(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject))
                     .And(a => _steps.ThenTheProcessStateIsUpdatedToManualChecksFailed(_processFixture.UpdateProcessRequest))
-                    .And(a => _steps.ThenTheProcessClosedEventIsRaised(_snsFixture, _processFixture.ProcessId))
+                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture.ProcessId))
                 .BDDfy();
         }
 
@@ -226,7 +242,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
                 .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
                 .Then(a => _steps.ThenTheProcessDataIsUpdated(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject))
                     .And(a => _steps.ThenTheProcessStateIsUpdatedToBreachChecksFailed(_processFixture.UpdateProcessRequest))
-                    .And(a => _steps.ThenTheProcessClosedEventIsRaised(_snsFixture, _processFixture.ProcessId))
+                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture.ProcessId))
                 .BDDfy();
         }
 

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateSoleToJointProcessTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateSoleToJointProcessTests.cs
@@ -49,11 +49,11 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         {
             if (disposing && !_disposed)
             {
-                if (_processFixture != null) _processFixture.Dispose();
-                if (_personFixture != null) _personFixture.Dispose();
-                if (_tenureFixture != null) _tenureFixture.Dispose();
-                if (_agreementsApiFixture != null) _agreementsApiFixture.Dispose();
-                if (_tenanciesApiFixture != null) _tenanciesApiFixture.Dispose();
+                _processFixture?.Dispose();
+                _personFixture?.Dispose();
+                _tenureFixture?.Dispose();
+                _agreementsApiFixture?.Dispose();
+                _tenanciesApiFixture?.Dispose();
 
                 _disposed = true;
             }

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateSoleToJointProcessTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateSoleToJointProcessTests.cs
@@ -54,6 +54,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
                 _tenureFixture?.Dispose();
                 _agreementsApiFixture?.Dispose();
                 _tenanciesApiFixture?.Dispose();
+                _snsFixture?.PurgeAllQueueMessages();
 
                 _disposed = true;
             }

--- a/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
+++ b/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
@@ -151,10 +151,14 @@ namespace ProcessesApi.Tests.V1.Services
         {
             // Arrange
             var process = CreateProcessWithCurrentState(fromState);
+            var formData = new Dictionary<string, object>()
+        {
+                { SoleToJointFormDataKeys.HasNotifiedResident, true }
+            };
 
             var triggerObject = CreateProcessTrigger(process,
                                                      SoleToJointPermittedTriggers.CloseProcess,
-                                                     new Dictionary<string, object>());
+                                                     formData);
 
             // Act
             await _classUnderTest.Process(triggerObject, process, _token).ConfigureAwait(false);

--- a/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
+++ b/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
@@ -169,7 +169,7 @@ namespace ProcessesApi.Tests.V1.Services
             // Assert
             CurrentStateShouldContainCorrectData(process,
                                                  triggerObject,
-                                                 SoleToJointStates.ProcessClosed,
+                                                 SharedProcessStates.ProcessClosed,
                                                  new List<string>());
             process.PreviousStates.LastOrDefault().State.Should().Be(fromState);
 

--- a/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
+++ b/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
@@ -1,7 +1,5 @@
-using Amazon.DynamoDBv2.DataModel;
 using AutoFixture;
 using FluentAssertions;
-using Hackney.Core.Testing.DynamoDb;
 using Moq;
 using ProcessesApi.V1.Domain;
 using System;

--- a/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
+++ b/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
@@ -24,8 +24,12 @@ namespace ProcessesApi.Tests.V1.Services
     {
         public SoleToJointService _classUnderTest;
         public Fixture _fixture = new Fixture();
-        private readonly IDynamoDbFixture _dbFixture;
-        private IDynamoDBContext _dynamoDb => _dbFixture.DynamoDbContext;
+        private readonly List<Action> _cleanup = new List<Action>();
+
+        private Mock<ISoleToJointAutomatedEligibilityChecksHelper> _mockAutomatedEligibilityChecksHelper;
+        private Mock<ISnsGateway> _mockSnsGateway;
+        private readonly Token _token = new Token();
+        private EntityEventSns _lastSnsEvent = new EntityEventSns();
 
         private Dictionary<string, object> _manualEligibilityPassData => new Dictionary<string, object>
         {
@@ -45,13 +49,6 @@ namespace ProcessesApi.Tests.V1.Services
             { SoleToJointFormDataKeys.BR17, "false" },
             { SoleToJointFormDataKeys.BR18, "false" }
         };
-
-        private Mock<ISoleToJointAutomatedEligibilityChecksHelper> _mockAutomatedEligibilityChecksHelper;
-        private Mock<ISnsGateway> _mockSnsGateway;
-
-        private readonly List<Action> _cleanup = new List<Action>();
-        private readonly Token _token = new Token();
-        private EntityEventSns _lastSnsEvent = new EntityEventSns();
 
         public void Dispose()
         {
@@ -74,7 +71,6 @@ namespace ProcessesApi.Tests.V1.Services
 
         public SoleToJointServiceTests(AwsMockWebApplicationFactory<Startup> appFactory)
         {
-            _dbFixture = appFactory.DynamoDbFixture;
             _mockSnsGateway = new Mock<ISnsGateway>();
             _mockAutomatedEligibilityChecksHelper = new Mock<ISoleToJointAutomatedEligibilityChecksHelper>();
 
@@ -119,6 +115,12 @@ namespace ProcessesApi.Tests.V1.Services
             process.CurrentState.UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, 2000);
         }
 
+        private void ThenProcessUpdatedEventIsRaised()
+        {
+            _mockSnsGateway.Verify(g => g.Publish(It.IsAny<EntityEventSns>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _lastSnsEvent.EventType.Should().Be(ProcessUpdatedEventConstants.EVENTTYPE);
+        }
+
         [Fact]
         public async Task InitialiseStateToSelectTenantsIfCurrentStateIsNotDefined()
         {
@@ -140,26 +142,32 @@ namespace ProcessesApi.Tests.V1.Services
             process.PreviousStates.Should().BeEmpty();
         }
 
-        // List all states where CancelProcess can be triggered from
+        // List all states that CloseProcess can be triggered from
         [Theory]
         [InlineData(SoleToJointStates.AutomatedChecksFailed)]
         [InlineData(SoleToJointStates.ManualChecksFailed)]
         [InlineData(SoleToJointStates.BreachChecksFailed)]
-        public async Task ProcessStateIsUpdatedToCloseProcess(string fromState)
+        public async Task ProcessStateIsUpdatedToProcessClosedAndProcessClosedEventIsRaised(string fromState)
         {
             // Arrange
             var process = CreateProcessWithCurrentState(fromState);
 
             var triggerObject = CreateProcessTrigger(process,
-                                                     SoleToJointPermittedTriggers.CancelProcess,
+                                                     SoleToJointPermittedTriggers.CloseProcess,
                                                      new Dictionary<string, object>());
+
             // Act
             await _classUnderTest.Process(triggerObject, process, _token).ConfigureAwait(false);
 
             // Assert
             CurrentStateShouldContainCorrectData(process,
-                                                 triggerObject, SoleToJointStates.ProcessCancelled, new List<string>());
+                                                 triggerObject,
+                                                 SoleToJointStates.ProcessClosed,
+                                                 new List<string>());
             process.PreviousStates.LastOrDefault().State.Should().Be(fromState);
+
+            _mockSnsGateway.Verify(g => g.Publish(It.IsAny<EntityEventSns>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+            _lastSnsEvent.EventType.Should().Be(ProcessClosedEventConstants.EVENTTYPE);
         }
 
         #region Automated eligibility checks
@@ -214,9 +222,10 @@ namespace ProcessesApi.Tests.V1.Services
             CurrentStateShouldContainCorrectData(process,
                                                  triggerObject,
                                                  SoleToJointStates.AutomatedChecksFailed,
-                                                 new List<string>() { SoleToJointPermittedTriggers.CancelProcess });
+                                                 new List<string>() { SoleToJointPermittedTriggers.CloseProcess });
             process.PreviousStates.LastOrDefault().State.Should().Be(SoleToJointStates.SelectTenants);
             _mockAutomatedEligibilityChecksHelper.Verify(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, tenantId), Times.Once());
+            ThenProcessUpdatedEventIsRaised();
         }
 
         [Fact]
@@ -269,38 +278,6 @@ namespace ProcessesApi.Tests.V1.Services
             func.Should().Throw<FormDataNotFoundException>().WithMessage(expectedErrorMessage);
         }
 
-        [Fact]
-        public async Task ProcessClosedEventIsRaisedWhenAutomaticEligibilityChecksFail()
-        {
-            // Arrange
-            var process = CreateProcessWithCurrentState(SoleToJointStates.SelectTenants);
-            var incomingTenantId = Guid.NewGuid();
-            var tenantId = Guid.NewGuid();
-
-            var triggerObject = CreateProcessTrigger(
-                process,
-                SoleToJointPermittedTriggers.CheckAutomatedEligibility,
-                new Dictionary<string, object>
-                {
-                    { SoleToJointFormDataKeys.IncomingTenantId, incomingTenantId },
-                    { SoleToJointFormDataKeys.TenantId, tenantId }
-                });
-
-            var snsEvent = new EntityEventSns();
-
-            _mockAutomatedEligibilityChecksHelper.Setup(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, tenantId)).ReturnsAsync(false);
-            _mockSnsGateway
-                .Setup(g => g.Publish(It.IsAny<EntityEventSns>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Callback<EntityEventSns, string, string>((ev, s1, s2) => snsEvent = ev);
-
-            // Act
-            await _classUnderTest.Process(triggerObject, process, _token).ConfigureAwait(false);
-
-            // Assert
-            _mockSnsGateway.Verify(g => g.Publish(It.IsAny<EntityEventSns>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            snsEvent.EventType.Should().Be(ProcessClosedEventConstants.EVENTTYPE);
-        }
-
         #endregion
 
         #region Manual eligibility checks
@@ -350,8 +327,9 @@ namespace ProcessesApi.Tests.V1.Services
             CurrentStateShouldContainCorrectData(process,
                                                  triggerObject,
                                                  SoleToJointStates.ManualChecksFailed,
-                                                 new List<string>() { SoleToJointPermittedTriggers.CancelProcess });
+                                                 new List<string>() { SoleToJointPermittedTriggers.CloseProcess });
             process.PreviousStates.LastOrDefault().State.Should().Be(SoleToJointStates.AutomatedChecksPassed);
+            ThenProcessUpdatedEventIsRaised();
         }
 
         [Fact]
@@ -378,28 +356,6 @@ namespace ProcessesApi.Tests.V1.Services
             Func<Task> func = async () => await _classUnderTest.Process(triggerObject, process, _token).ConfigureAwait(false);
             // Assert
             func.Should().Throw<FormDataNotFoundException>().WithMessage(expectedErrorMessage);
-        }
-
-
-        [Fact]
-        public async Task ProcessClosedEventIsRaisedWhenManualEligibilityChecksFail()
-        {
-            // Arrange
-            var process = CreateProcessWithCurrentState(SoleToJointStates.AutomatedChecksPassed);
-
-            var eligibilityFormData = _manualEligibilityPassData;
-            eligibilityFormData[SoleToJointFormDataKeys.BR11] = "false";
-
-            var triggerObject = CreateProcessTrigger(process,
-                SoleToJointPermittedTriggers.CheckManualEligibility,
-                eligibilityFormData);
-
-            // Act
-            await _classUnderTest.Process(triggerObject, process, _token).ConfigureAwait(false);
-
-            // Assert
-            _mockSnsGateway.Verify(g => g.Publish(It.IsAny<EntityEventSns>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            _lastSnsEvent.EventType.Should().Be(ProcessClosedEventConstants.EVENTTYPE);
         }
 
         #endregion
@@ -446,9 +402,10 @@ namespace ProcessesApi.Tests.V1.Services
             // Assert
             CurrentStateShouldContainCorrectData(
                 process, trigger, SoleToJointStates.BreachChecksFailed,
-                new List<string> { SoleToJointPermittedTriggers.CancelProcess });
+                new List<string> { SoleToJointPermittedTriggers.CloseProcess });
 
             process.PreviousStates.Last().State.Should().Be(SoleToJointStates.ManualChecksPassed);
+            ThenProcessUpdatedEventIsRaised();
         }
 
         [Theory]
@@ -474,25 +431,6 @@ namespace ProcessesApi.Tests.V1.Services
                 .Should().Throw<FormDataNotFoundException>().WithMessage(expectedErrorMessage);
         }
 
-        [Fact]
-        public async Task ProcessClosedEventIsRaisedWhenTenancyBreachChecksFail()
-        {
-            // Arrange
-            var process = CreateProcessWithCurrentState(SoleToJointStates.ManualChecksPassed);
-
-            _tenancyBreachPassData[SoleToJointFormDataKeys.BR5] = "true";
-
-            var trigger = CreateProcessTrigger(
-                process, SoleToJointPermittedTriggers.CheckTenancyBreach, _tenancyBreachPassData);
-
-            // Act
-            await _classUnderTest.Process(trigger, process, _token).ConfigureAwait(false);
-
-            // Assert
-            _mockSnsGateway.Verify(g => g.Publish(It.IsAny<EntityEventSns>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            _lastSnsEvent.EventType.Should().Be(ProcessClosedEventConstants.EVENTTYPE);
-        }
-
         #endregion
 
         #region Request Documents
@@ -514,22 +452,7 @@ namespace ProcessesApi.Tests.V1.Services
                 new List<string> { /* TODO: Add next trigger(s) here */ });
 
             process.PreviousStates.Last().State.Should().Be(SoleToJointStates.BreachChecksPassed);
-        }
-
-        [Fact]
-        public async Task ProcessUpdatedEventIsRasiedWhenDocumentsRequestedAppointmentIsBooked()
-        {
-            // Arrange
-            var process = CreateProcessWithCurrentState(SoleToJointStates.BreachChecksPassed);
-            var formData = new Dictionary<string, object>() { { SoleToJointFormDataKeys.AppointmentDateTime, _fixture.Create<DateTime>() } };
-            var trigger = CreateProcessTrigger(process, SoleToJointPermittedTriggers.RequestDocumentsAppointment, formData);
-
-            // Act
-            await _classUnderTest.Process(trigger, process, _token).ConfigureAwait(false);
-
-            // Assert
-            _mockSnsGateway.Verify(g => g.Publish(It.IsAny<EntityEventSns>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            _lastSnsEvent.EventType.Should().Be(ProcessUpdatedEventConstants.EVENTTYPE);
+            ThenProcessUpdatedEventIsRaised();
         }
 
         [Fact]

--- a/ProcessesApi/V1/Domain/SharedProcessConstants.cs
+++ b/ProcessesApi/V1/Domain/SharedProcessConstants.cs
@@ -3,6 +3,8 @@ namespace ProcessesApi.V1.Domain
     public static class SharedProcessStates
     {
         public const string ApplicationInitialised = "ApplicationInitialised";
+        public const string ProcessClosed = "ProcessClosed";
+        public const string ProcessCancelled = "ProcessCancelled";
     }
 
     public static class SharedInternalTriggers

--- a/ProcessesApi/V1/Domain/SoleToJoint/SoleToJointConstants.cs
+++ b/ProcessesApi/V1/Domain/SoleToJoint/SoleToJointConstants.cs
@@ -13,6 +13,7 @@ namespace ProcessesApi.V1.Domain
         public const string BreachChecksPassed = "BreachChecksPassed";
         public const string DocumentsRequestedAppointment = "DocumentsRequestedAppointment";
         public const string ProcessCancelled = "ProcessCancelled";
+        public const string ProcessClosed = "ProcessClosed";
     }
 
     public static class SoleToJointPermittedTriggers
@@ -23,6 +24,7 @@ namespace ProcessesApi.V1.Domain
         public const string CheckTenancyBreach = "CheckTenancyBreach";
         public const string RequestDocumentsAppointment = "RequestDocumentsAppointment";
         public const string CancelProcess = "CancelProcess";
+        public const string CloseProcess = "CloseProcess";
     }
 
     public static class SoleToJointInternalTriggers
@@ -118,10 +120,6 @@ namespace ProcessesApi.V1.Domain
         ///     Other than a NOSP, does the tenant have any live notices against the tenure, e.g. a breach of tenancy?
         /// </summary>
         public const string BR18 = "br18";
-
-
-
-
 
         #endregion
     }

--- a/ProcessesApi/V1/Domain/SoleToJoint/SoleToJointConstants.cs
+++ b/ProcessesApi/V1/Domain/SoleToJoint/SoleToJointConstants.cs
@@ -42,7 +42,7 @@ namespace ProcessesApi.V1.Domain
     public static class SoleToJointFormDataKeys
     {
         public const string HasNotifiedResident = "hasNotifiedResident";
-        
+
         #region Automated eligibility checks
 
         /// <summary>

--- a/ProcessesApi/V1/Domain/SoleToJoint/SoleToJointConstants.cs
+++ b/ProcessesApi/V1/Domain/SoleToJoint/SoleToJointConstants.cs
@@ -4,8 +4,6 @@ namespace ProcessesApi.V1.Domain
 {
     public static class SoleToJointStates
     {
-        public const string ProcessClosed = "ProcessClosed";
-        public const string ProcessCancelled = "ProcessCancelled";
         public const string SelectTenants = "SelectTenants";
         public const string AutomatedChecksFailed = "AutomatedChecksFailed";
         public const string AutomatedChecksPassed = "AutomatedChecksPassed";

--- a/ProcessesApi/V1/Factories/ISnsFactory.cs
+++ b/ProcessesApi/V1/Factories/ISnsFactory.cs
@@ -10,7 +10,7 @@ namespace ProcessesApi.V1.Factories
     {
         EntityEventSns ProcessStarted(Process process, Token token);
 
-        EntityEventSns ProcessClosed(Process process, Token token, string description);
+        EntityEventSns ProcessClosed(Process process, Token token);
 
         EntityEventSns ProcessUpdatedWithMessage(Process process, Token token, string description);
         EntityEventSns ProcessUpdated(Guid id, UpdateEntityResult<ProcessState> updateResult, Token token);

--- a/ProcessesApi/V1/Factories/ProcessesSnsFactory.cs
+++ b/ProcessesApi/V1/Factories/ProcessesSnsFactory.cs
@@ -29,7 +29,7 @@ namespace ProcessesApi.V1.Factories
             };
         }
 
-        public EntityEventSns ProcessClosed(Process process, Token token, string description)
+        public EntityEventSns ProcessClosed(Process process, Token token)
         {
             return new EntityEventSns
             {
@@ -43,7 +43,7 @@ namespace ProcessesApi.V1.Factories
                 SourceSystem = ProcessClosedEventConstants.SOURCE_SYSTEM,
                 EventData = new EventData
                 {
-                    NewData = description
+                    NewData = "Process Closed"
                 },
                 User = new User
                 {

--- a/ProcessesApi/V1/Factories/ProcessesSnsFactory.cs
+++ b/ProcessesApi/V1/Factories/ProcessesSnsFactory.cs
@@ -1,6 +1,5 @@
 using Hackney.Core.JWT;
 using Hackney.Core.Sns;
-using Newtonsoft.Json;
 using ProcessesApi.V1.Domain;
 using ProcessesApi.V1.Infrastructure;
 using ProcessesApi.V1.Infrastructure.JWT;

--- a/ProcessesApi/V1/Services/ProcessService.cs
+++ b/ProcessesApi/V1/Services/ProcessService.cs
@@ -105,10 +105,10 @@ namespace ProcessesApi.V1.Services
             await _snsGateway.Publish(processSnsMessage, processTopicArn).ConfigureAwait(false);
         }
 
-        protected async Task PublishProcessClosedEvent(string description)
+        protected async Task PublishProcessClosedEvent()
         {
             var processTopicArn = Environment.GetEnvironmentVariable("PROCESS_SNS_ARN");
-            var processSnsMessage = _snsFactory.ProcessClosed(_process, _token, description);
+            var processSnsMessage = _snsFactory.ProcessClosed(_process, _token);
 
             await _snsGateway.Publish(processSnsMessage, processTopicArn).ConfigureAwait(false);
         }

--- a/ProcessesApi/V1/Services/SoleToJointService.cs
+++ b/ProcessesApi/V1/Services/SoleToJointService.cs
@@ -99,7 +99,7 @@ namespace ProcessesApi.V1.Services
 
             if (Boolean.TryParse(hasNotifiedResidentString.ToString(), out bool hasNotifiedResident))
             {
-                if(!hasNotifiedResident) throw new FormDataInvalidException("Housing Officer must notify the resident before closing this process.");
+                if (!hasNotifiedResident) throw new FormDataInvalidException("Housing Officer must notify the resident before closing this process.");
                 await PublishProcessClosedEvent().ConfigureAwait(false);
             }
             else

--- a/ProcessesApi/V1/Services/SoleToJointService.cs
+++ b/ProcessesApi/V1/Services/SoleToJointService.cs
@@ -185,7 +185,7 @@ namespace ProcessesApi.V1.Services
                     .Permit(SoleToJointInternalTriggers.EligibiltyPassed, SoleToJointStates.AutomatedChecksPassed);
 
             _machine.Configure(SoleToJointStates.AutomatedChecksFailed)
-                    .Permit(SoleToJointPermittedTriggers.CloseProcess, SoleToJointStates.ProcessClosed);
+                    .Permit(SoleToJointPermittedTriggers.CloseProcess, SharedProcessStates.ProcessClosed);
 
             _machine.Configure(SoleToJointStates.AutomatedChecksPassed)
                     .InternalTransitionAsync(SoleToJointPermittedTriggers.CheckManualEligibility, async (x) => await CheckManualEligibility(x).ConfigureAwait(false))
@@ -193,7 +193,7 @@ namespace ProcessesApi.V1.Services
                     .Permit(SoleToJointInternalTriggers.ManualEligibilityFailed, SoleToJointStates.ManualChecksFailed);
 
             _machine.Configure(SoleToJointStates.ManualChecksFailed)
-                    .Permit(SoleToJointPermittedTriggers.CloseProcess, SoleToJointStates.ProcessClosed);
+                    .Permit(SoleToJointPermittedTriggers.CloseProcess, SharedProcessStates.ProcessClosed);
 
             _machine.Configure(SoleToJointStates.ManualChecksPassed)
                     .InternalTransitionAsync(SoleToJointPermittedTriggers.CheckTenancyBreach, async (x) => await CheckTenancyBreach(x).ConfigureAwait(false))
@@ -201,7 +201,7 @@ namespace ProcessesApi.V1.Services
                     .Permit(SoleToJointInternalTriggers.BreachChecksFailed, SoleToJointStates.BreachChecksFailed);
 
             _machine.Configure(SoleToJointStates.BreachChecksFailed)
-                    .Permit(SoleToJointPermittedTriggers.CloseProcess, SoleToJointStates.ProcessClosed);
+                    .Permit(SoleToJointPermittedTriggers.CloseProcess, SharedProcessStates.ProcessClosed);
 
             _machine.Configure(SoleToJointStates.BreachChecksPassed)
                     .Permit(SoleToJointPermittedTriggers.RequestDocumentsDes, SoleToJointStates.DocumentsRequestedDes)
@@ -220,7 +220,7 @@ namespace ProcessesApi.V1.Services
         protected override void SetUpStateActions()
         {
             ConfigureAsync(SoleToJointStates.SelectTenants, Assignment.Create("tenants"), (x) => PublishProcessStartedEvent());
-            ConfigureAsync(SoleToJointStates.ProcessClosed, Assignment.Create("tenants"), OnProcessClosed);
+            ConfigureAsync(SharedProcessStates.ProcessClosed, Assignment.Create("tenants"), OnProcessClosed);
 
             ConfigureAsync(SoleToJointStates.AutomatedChecksFailed, Assignment.Create("tenants"), OnAutomatedCheckFailed);
             Configure(SoleToJointStates.AutomatedChecksPassed, Assignment.Create("tenants"), AddIncomingTenantId);

--- a/ProcessesApi/V1/UseCase/UpdateProcessByIdUsecase.cs
+++ b/ProcessesApi/V1/UseCase/UpdateProcessByIdUsecase.cs
@@ -30,10 +30,10 @@ namespace ProcessesApi.V1.UseCase
             var result = await _processGateway.UpdateProcessById(query, requestObject, requestBody, ifMatch).ConfigureAwait(false);
 
             if (result == null) return null;
+
             var processSnsMessage = _snsFactory.ProcessUpdated(query.Id, result, token);
             var topicArn = Environment.GetEnvironmentVariable("PROCESS_SNS_ARN");
             await _snsGateway.Publish(processSnsMessage, topicArn).ConfigureAwait(false);
-
 
             return result.UpdatedEntity;
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - 8000:8000
 
   localstack:
-    image: localstack/localstack    
+    image: localstack/localstack:0.14.1
     hostname: awslocal    
     ports:
       - "4566:4566"      


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-2835

## Describe this PR

- Add CloseProcess & publish ProcessClosed events when it is triggered
- Update some state transitions that were mistakenly triggering ProcessClosed events instead of ProcessUpdated events (e.g. on manual checks failing)
- Fix bug in the E2E tests where SQS messages were not correctly picked up by the SnsFixture, causing falsely passing tests

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

The bug with the events in the E2E tests likely have affected other APIs, which will need to be updated.
