### PR TITLE
Bugfix: Add validation for FormData

### DIFF
--- a/ProcessesApi.Tests/V1/Boundary/Validation/UpdateProcessRequestObjectValidatorTests.cs
+++ b/ProcessesApi.Tests/V1/Boundary/Validation/UpdateProcessRequestObjectValidatorTests.cs
@@ -17,20 +17,59 @@ namespace ProcessesApi.Tests.V1.Boundary.Validation
         }
 
         [Fact]
+        public void RequestShouldErrorWithNullFormData()
+        {
+            //Arrange
+            var model = new UpdateProcessRequestObject
+            {
+                FormData = null,
+                Documents = new List<Guid>()
+            };
+            //Act
+            var result = _classUnderTest.TestValidate(model);
+            //Assert
+            result.ShouldHaveValidationErrorFor(x => x.FormData);
+        }
+
+        [Fact]
+        public void RequestShouldNotErrorWithValidFormData()
+        {
+            //Arrange
+            var model = new UpdateProcessRequestObject
+            {
+                FormData = new Dictionary<string, object>(),
+                Documents = new List<Guid>()
+            };
+            //Act
+            var result = _classUnderTest.TestValidate(model);
+            //Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.FormData);
+        }
+
+        [Fact]
         public void RequestShouldErrorWithEmptyDocumentIDs()
         {
             //Arrange
-            var model = new UpdateProcessRequestObject() { Documents = new List<Guid> { Guid.Empty } };
+            var model = new UpdateProcessRequestObject
+            {
+                FormData = null,
+                Documents = new List<Guid> { Guid.Empty }
+            };
             //Act
             var result = _classUnderTest.TestValidate(model);
             //Assert
             result.ShouldHaveValidationErrorFor(x => x.Documents);
         }
+
         [Fact]
         public void RequestShouldNotErrorWithValidDocumentIDs()
         {
             //Arrange
-            var model = new UpdateProcessRequestObject() { Documents = new List<Guid> { Guid.NewGuid() } };
+            var model = new UpdateProcessRequestObject
+            {
+                FormData = null,
+                Documents = new List<Guid> { Guid.NewGuid() }
+            };
             //Act
             var result = _classUnderTest.TestValidate(model);
             //Assert

--- a/ProcessesApi/V1/Boundary/Request/Validation/UpdateProcessRequestObjectValidator.cs
+++ b/ProcessesApi/V1/Boundary/Request/Validation/UpdateProcessRequestObjectValidator.cs
@@ -7,6 +7,7 @@ namespace ProcessesApi.V1.Boundary.Request.Validation
     {
         public UpdateProcessRequestObjectValidator()
         {
+            RuleFor(x => x.FormData).NotNull();
             RuleForEach(x => x.Documents).NotNull()
                                         .NotEqual(Guid.Empty);
         }


### PR DESCRIPTION
Add validation so that FormData cannot be null when triggering a state change, as per the [SwaggerHub spec](https://app.swaggerhub.com/apis/Hackney/ProcessesApi/1.0.0#/default/patch_api_v1_process__processName___id___processTrigger_).

_Note: FormData can still be empty if no values are required, just not null._
