### PR TITLE
Mttl 2879 - Implement TenureInvestigation trigger

### DIFF
--- a/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -256,6 +256,27 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
             UpdateProcessRequestObject.FormData.Remove(SoleToJointFormDataKeys.IncomingTenantLivingInProperty);
         }
 
+        public void GivenATenureInvestigationRequest(string tenureInvestigationRecommendation)
+        {
+            GivenAnUpdateSoleToJointProcessRequest(SoleToJointPermittedTriggers.TenureInvestigation);
+
+            UpdateProcessRequestObject.FormData = new Dictionary<string, object>
+            {
+                { SoleToJointFormDataKeys.TenureInvestigationRecommendation, tenureInvestigationRecommendation }
+            };
+        }
+
+        public void GivenATenureInvestigationRequestWithMissingData()
+        {
+            GivenAnUpdateSoleToJointProcessRequest(SoleToJointPermittedTriggers.TenureInvestigation);
+        }
+
+        public void GivenATenureInvestigationRequestWithInvalidData()
+        {
+            GivenATenureInvestigationRequest("invalid value");
+        }
+
+
         public void GivenAnUpdateProcessByIdRequest()
         {
             UpdateProcessByIdRequest = new ProcessQuery

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
@@ -163,6 +163,20 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             await CheckProcessState(request.Id, SoleToJointStates.ApplicationSubmitted, SoleToJointStates.DocumentChecksPassed).ConfigureAwait(false);
         }
 
+        public async Task ThenTheProcessStateIsUpdatedToTenureInvestigationFailed(UpdateProcessQuery request)
+        {
+            await CheckProcessState(request.Id, SoleToJointStates.TenureInvestigationFailed, SoleToJointStates.ApplicationSubmitted).ConfigureAwait(false);
+        }
+
+        public async Task ThenTheProcessStateIsUpdatedToTenureInvestigationPassed(UpdateProcessQuery request)
+        {
+            await CheckProcessState(request.Id, SoleToJointStates.TenureInvestigationPassed, SoleToJointStates.ApplicationSubmitted).ConfigureAwait(false);
+        }
+
+        public async Task ThenTheProcessStateIsUpdatedToTenureInvestigationPassedWithInterview(UpdateProcessQuery request)
+        {
+            await CheckProcessState(request.Id, SoleToJointStates.TenureInvestigationPassedWithInt, SoleToJointStates.ApplicationSubmitted).ConfigureAwait(false);
+        }
 
         public async Task ThenTheProcessClosedEventIsRaised(ISnsFixture snsFixture, Guid processId)
         {

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/UpdateSoleToJointProcessSteps.cs
@@ -163,19 +163,9 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             await CheckProcessState(request.Id, SoleToJointStates.ApplicationSubmitted, SoleToJointStates.DocumentChecksPassed).ConfigureAwait(false);
         }
 
-        public async Task ThenTheProcessStateIsUpdatedToTenureInvestigationFailed(UpdateProcessQuery request)
+        public async Task ThenTheProcessStateIsUpdatedToShowResultsOfTenureInvestigation(UpdateProcessQuery request, string destinationState)
         {
-            await CheckProcessState(request.Id, SoleToJointStates.TenureInvestigationFailed, SoleToJointStates.ApplicationSubmitted).ConfigureAwait(false);
-        }
-
-        public async Task ThenTheProcessStateIsUpdatedToTenureInvestigationPassed(UpdateProcessQuery request)
-        {
-            await CheckProcessState(request.Id, SoleToJointStates.TenureInvestigationPassed, SoleToJointStates.ApplicationSubmitted).ConfigureAwait(false);
-        }
-
-        public async Task ThenTheProcessStateIsUpdatedToTenureInvestigationPassedWithInterview(UpdateProcessQuery request)
-        {
-            await CheckProcessState(request.Id, SoleToJointStates.TenureInvestigationPassedWithInt, SoleToJointStates.ApplicationSubmitted).ConfigureAwait(false);
+            await CheckProcessState(request.Id, destinationState, SoleToJointStates.ApplicationSubmitted).ConfigureAwait(false);
         }
 
         public async Task ThenTheProcessClosedEventIsRaised(ISnsFixture snsFixture, Guid processId)

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateSoleToJointProcessTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateSoleToJointProcessTests.cs
@@ -356,7 +356,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
 
         #endregion
 
-        #region Submit for tenure investigation
+        #region Tenure Investigation
 
         [Fact]
         public void ProcessStateIsUpdatedToApplicationSubmitted()
@@ -369,6 +369,58 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
                 .BDDfy();
         }
 
+        [Fact]
+        public void ProcessStateIsUpdatedToTenureInvestigationPassed()
+        {
+            this.Given(g => _processFixture.GivenASoleToJointProcessExists(SoleToJointStates.ApplicationSubmitted))
+                    .And(a => _processFixture.GivenATenureInvestigationRequest(SoleToJointFormDataValues.Approve))
+                .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
+                .Then(a => _steps.ThenTheProcessStateIsUpdatedToTenureInvestigationPassed(_processFixture.UpdateProcessRequest))
+                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture.ProcessId, SoleToJointStates.ApplicationSubmitted, SoleToJointStates.TenureInvestigationPassed))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ProcessStateIsUpdatedToTenureInvestigationPassedWithInterview()
+        {
+            this.Given(g => _processFixture.GivenASoleToJointProcessExists(SoleToJointStates.ApplicationSubmitted))
+                    .And(a => _processFixture.GivenATenureInvestigationRequest(SoleToJointFormDataValues.Appointment))
+                .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
+                .Then(a => _steps.ThenTheProcessStateIsUpdatedToTenureInvestigationPassedWithInterview(_processFixture.UpdateProcessRequest))
+                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture.ProcessId, SoleToJointStates.ApplicationSubmitted, SoleToJointStates.TenureInvestigationPassedWithInt))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ProcessStateIsUpdatedToTenureInvestigationFailed()
+        {
+            this.Given(g => _processFixture.GivenASoleToJointProcessExists(SoleToJointStates.ApplicationSubmitted))
+                    .And(a => _processFixture.GivenATenureInvestigationRequest(SoleToJointFormDataValues.Decline))
+                .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
+                .Then(a => _steps.ThenTheProcessStateIsUpdatedToTenureInvestigationFailed(_processFixture.UpdateProcessRequest))
+                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture.ProcessId, SoleToJointStates.ApplicationSubmitted, SoleToJointStates.TenureInvestigationFailed))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void BadRequestIsReturnedWhenTenureInvestigationRecommendationIsMissing()
+        {
+            this.Given(g => _processFixture.GivenASoleToJointProcessExists(SoleToJointStates.ApplicationSubmitted))
+                    .And(a => _processFixture.GivenATenureInvestigationRequestWithMissingData())
+                .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
+                .Then(a => _steps.ThenBadRequestIsReturned())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void BadRequestIsReturnedWhenTenureInvestigationRecommendationIsInvalid()
+        {
+            this.Given(g => _processFixture.GivenASoleToJointProcessExists(SoleToJointStates.ApplicationSubmitted))
+                    .And(a => _processFixture.GivenATenureInvestigationRequestWithInvalidData())
+                .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
+                .Then(a => _steps.ThenBadRequestIsReturned())
+                .BDDfy();
+        }
 
         #endregion
     }

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateSoleToJointProcessTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/UpdateSoleToJointProcessTests.cs
@@ -369,36 +369,17 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
                 .BDDfy();
         }
 
-        [Fact]
-        public void ProcessStateIsUpdatedToTenureInvestigationPassed()
+        [Theory]
+        [InlineData(SoleToJointFormDataValues.Appointment, SoleToJointStates.TenureInvestigationPassedWithInt)]
+        [InlineData(SoleToJointFormDataValues.Approve, SoleToJointStates.TenureInvestigationPassed)]
+        [InlineData(SoleToJointFormDataValues.Decline, SoleToJointStates.TenureInvestigationFailed)]
+        public void ProcessStateIsUpdatedToShowResultOfTenureInvestigation(string tenureInvestigationRecommendation, string destinationState)
         {
             this.Given(g => _processFixture.GivenASoleToJointProcessExists(SoleToJointStates.ApplicationSubmitted))
-                    .And(a => _processFixture.GivenATenureInvestigationRequest(SoleToJointFormDataValues.Approve))
+                    .And(a => _processFixture.GivenATenureInvestigationRequest(tenureInvestigationRecommendation))
                 .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
-                .Then(a => _steps.ThenTheProcessStateIsUpdatedToTenureInvestigationPassed(_processFixture.UpdateProcessRequest))
-                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture.ProcessId, SoleToJointStates.ApplicationSubmitted, SoleToJointStates.TenureInvestigationPassed))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void ProcessStateIsUpdatedToTenureInvestigationPassedWithInterview()
-        {
-            this.Given(g => _processFixture.GivenASoleToJointProcessExists(SoleToJointStates.ApplicationSubmitted))
-                    .And(a => _processFixture.GivenATenureInvestigationRequest(SoleToJointFormDataValues.Appointment))
-                .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
-                .Then(a => _steps.ThenTheProcessStateIsUpdatedToTenureInvestigationPassedWithInterview(_processFixture.UpdateProcessRequest))
-                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture.ProcessId, SoleToJointStates.ApplicationSubmitted, SoleToJointStates.TenureInvestigationPassedWithInt))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void ProcessStateIsUpdatedToTenureInvestigationFailed()
-        {
-            this.Given(g => _processFixture.GivenASoleToJointProcessExists(SoleToJointStates.ApplicationSubmitted))
-                    .And(a => _processFixture.GivenATenureInvestigationRequest(SoleToJointFormDataValues.Decline))
-                .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
-                .Then(a => _steps.ThenTheProcessStateIsUpdatedToTenureInvestigationFailed(_processFixture.UpdateProcessRequest))
-                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture.ProcessId, SoleToJointStates.ApplicationSubmitted, SoleToJointStates.TenureInvestigationFailed))
+                .Then(a => _steps.ThenTheProcessStateIsUpdatedToShowResultsOfTenureInvestigation(_processFixture.UpdateProcessRequest, destinationState))
+                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaised(_snsFixture, _processFixture.ProcessId, SoleToJointStates.ApplicationSubmitted, destinationState))
                 .BDDfy();
         }
 

--- a/ProcessesApi/V1/Domain/SoleToJoint/SoleToJointConstants.cs
+++ b/ProcessesApi/V1/Domain/SoleToJoint/SoleToJointConstants.cs
@@ -16,6 +16,9 @@ namespace ProcessesApi.V1.Domain
         public const string DocumentsAppointmentRescheduled = "DocumentsAppointmentRescheduled";
         public const string DocumentChecksPassed = "DocumentChecksPassed";
         public const string ApplicationSubmitted = "ApplicationSubmitted";
+        public const string TenureInvestigationFailed = "TenureInvestigationFailed";
+        public const string TenureInvestigationPassed = "TenureInvestigationPassed";
+        public const string TenureInvestigationPassedWithInt = "TenureInvestigationPassedWithInt";
     }
 
     public static class SoleToJointPermittedTriggers
@@ -31,6 +34,7 @@ namespace ProcessesApi.V1.Domain
         public const string RescheduleDocumentsAppointment = "RescheduleDocumentsAppointment";
         public const string ReviewDocuments = "ReviewDocuments";
         public const string SubmitApplication = "SubmitApplication";
+        public const string TenureInvestigation = "TenureInvestigation";
     }
 
     public static class SoleToJointInternalTriggers
@@ -42,7 +46,9 @@ namespace ProcessesApi.V1.Domain
         public const string BreachChecksFailed = "BreachChecksFailed";
         public const string BreachChecksPassed = "BreachChecksPassed";
         public const string DocumentChecksPassed = "DocumentChecksPassed";
-
+        public const string TenureInvestigationFailed = "TenureInvestigationFailed";
+        public const string TenureInvestigationPassed = "TenureInvestigationPassed";
+        public const string TenureInvestigationPassedWithInt = "TenureInvestigationPassedWithInt";
     }
 
     // NOTE: Form data key values must be camelCase to avoid issues with Json Serialiser in E2E tests
@@ -163,6 +169,21 @@ namespace ProcessesApi.V1.Domain
         public const string IncomingTenantLivingInProperty = "incomingTenantLivingInProperty";
 
         #endregion
-    }
 
+        #region Tenure Investigation
+
+        public const string TenureInvestigationRecommendation = "tenureInvestigationRecommendation";
+
+        #endregion
+    }
+    public static class SoleToJointFormDataValues
+    {
+        #region Tenure Investigation
+
+        public const string Approve = "approve";
+        public const string Decline = "decline";
+        public const string Appointment = "appointment";
+
+        #endregion
+    }
 }

--- a/ProcessesApi/V1/Services/SoleToJointService.cs
+++ b/ProcessesApi/V1/Services/SoleToJointService.cs
@@ -113,7 +113,7 @@ namespace ProcessesApi.V1.Services
                     break;
                 case SoleToJointFormDataValues.Decline:
                     processRequest.Trigger = SoleToJointInternalTriggers.TenureInvestigationFailed;
-                    break; 
+                    break;
                 default:
                     throw new FormDataInvalidException(String.Format("Tenure Investigation Recommendation must be one of: [{0}, {1}, {2}], but the value provided was: '{3}'.",
                                                                      SoleToJointFormDataValues.Appointment,


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-2879

## Describe this PR

Implement TenureInvestigation trigger. 

This trigger expects the following request data from the FE:
```json
{
  "formData": {
     "tenureInvestigationRecommendation": "approve | decline | appointment"
  },
  "documents": []
}

```
Based on that data, it will transition to `TenureInvestigationFailed`, `TenureInvestigationPassed`, or `TenureInvestigationPassedWithInt` and fire a relevant `ProcessUpdated` event.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
