### PR TITLE
Bugfix: Add permission to query indexes

### DIFF
--- a/ProcessesApi/serverless.yml
+++ b/ProcessesApi/serverless.yml
@@ -126,6 +126,12 @@ resources:
                           - Ref: 'AWS::Region'
                           - Ref: 'AWS::AccountId'
                           - 'table/Processes'
+                    - 'Fn::Join':
+                        - ':'
+                        - - 'arn:aws:dynamodb'
+                          - Ref: 'AWS::Region'
+                          - Ref: 'AWS::AccountId'
+                          - 'table/Processes/index/*' 
                 - Effect: Allow
                   Action:
                     - "dynamodb:BatchGet*"


### PR DESCRIPTION
Fix Get by Target Id endpoint failing in dev by adding permissions to query indexes on the processes table