### PR TITLE
Mttl 3115 - Add tenure start date at the end of the process

### DIFF
--- a/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -467,6 +467,7 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
         public void GivenAUpdateTenureRequest()
         {
             GivenAnUpdateProcessRequest(SoleToJointPermittedTriggers.UpdateTenure);
+            UpdateProcessRequestObject.FormData.Add(SoleToJointKeys.TenureStartDate, DateTime.Parse(_fixture.Create<DateTime>().ToLongDateString()));
         }
 
         public void GivenANameSubmittedRequest()

--- a/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -187,6 +187,12 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
             UpdateProcessRequestObject.FormData.Add(SharedKeys.Comment, "This is a comment");
         }
 
+        public void GivenACompleteProcessRequest()
+        {
+            GivenAnUpdateProcessRequest(SharedPermittedTriggers.CompleteProcess);
+            UpdateProcessRequestObject.FormData.Add(SharedKeys.HasNotifiedResident, true);
+        }
+
         public void GivenACheckAutomatedEligibilityRequest()
         {
             GivenAnUpdateProcessRequest(SoleToJointPermittedTriggers.CheckAutomatedEligibility);
@@ -461,8 +467,6 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
         public void GivenAUpdateTenureRequest()
         {
             GivenAnUpdateProcessRequest(SoleToJointPermittedTriggers.UpdateTenure);
-            UpdateProcessRequestObject.FormData.Add(SharedKeys.HasNotifiedResident, true);
-            UpdateProcessRequestObject.FormData.Add(SharedKeys.Reason, "This is a reason");
         }
 
         public void GivenANameSubmittedRequest()

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/ChangeOfNameSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/ChangeOfNameSteps.cs
@@ -10,11 +10,11 @@ using System.Threading.Tasks;
 
 namespace ProcessesApi.Tests.V1.E2ETests.Steps
 {
-    public class UpdateChangeOfNameProcessSteps : UpdateProcessBaseSteps
+    public class ChangeOfNameSteps : UpdateProcessBaseSteps
     {
         private readonly IDynamoDbFixture _dbFixture;
 
-        public UpdateChangeOfNameProcessSteps(HttpClient httpClient, IDynamoDbFixture dbFixture) : base(httpClient, dbFixture)
+        public ChangeOfNameSteps(HttpClient httpClient, IDynamoDbFixture dbFixture) : base(httpClient, dbFixture)
         {
             _dbFixture = dbFixture;
         }

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/ProcessBaseSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/ProcessBaseSteps.cs
@@ -102,6 +102,11 @@ namespace ProcessesApi.Tests.V1.E2ETests.Steps
             await CheckProcessState(request.Id, SharedStates.ProcessClosed, previousState).ConfigureAwait(false);
         }
 
+        public async Task ThenTheProcessStateIsUpdatedToProcessCompleted(UpdateProcessQuery request, string previousState)
+        {
+            await CheckProcessState(request.Id, SharedStates.ProcessCompleted, previousState).ConfigureAwait(false);
+        }
+
         public async Task ThenTheProcessStateIsUpdatedToDocumentsAppointmentRescheduled(UpdateProcessQuery request)
         {
             await CheckProcessState(request.Id, SharedStates.DocumentsAppointmentRescheduled, SharedStates.DocumentsRequestedAppointment).ConfigureAwait(false);
@@ -207,6 +212,7 @@ namespace ProcessesApi.Tests.V1.E2ETests.Steps
         public async Task ThenTheProcessUpdatedEventIsRaised(ISnsFixture snsFixture, Guid processId, string oldState, string newState)
         {
             await VerifyProcessUpdatedEventIsRaised(snsFixture, processId, oldState, newState).ConfigureAwait(false);
+            // todo figure out how to verify other events e.g. tenure updated
         }
 
         public async Task ThenTheProcessUpdatedEventIsRaisedWithAppointmentDetails(ISnsFixture snsFixture, Guid processId, string oldState, string newState)
@@ -329,7 +335,6 @@ namespace ProcessesApi.Tests.V1.E2ETests.Steps
         public async Task ThenTheProcessCompletedEventIsRaised(ISnsFixture snsFixture, Guid processId, string oldState, string newState)
         {
             await VerifyProcessCompletedEventIsRaised(snsFixture, processId, oldState, newState).ConfigureAwait(false);
-            // todo figure out how to verify other events e.g. tenure updated
         }
         # endregion
     }

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/SoleToJointSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/SoleToJointSteps.cs
@@ -79,7 +79,7 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
         {
             await CheckProcessState(request.Id, SharedStates.DocumentsRequestedAppointment, SoleToJointStates.BreachChecksPassed).ConfigureAwait(false);
         }
-        public async Task ThenTheProcessStateIsUpdatedToUpdateTenure(UpdateProcessQuery request, string initialState, Guid incomingTenantId)
+        public async Task ThenTheProcessStateIsUpdatedToUpdateTenure(UpdateProcessQuery request, UpdateProcessRequestObject requestObject, string initialState, Guid incomingTenantId)
         {
             await CheckProcessState(request.Id, SoleToJointStates.TenureUpdated, initialState).ConfigureAwait(false);
 
@@ -88,12 +88,13 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             var newTenureDetails = process.RelatedEntities.Find(x => x.TargetType == TargetType.tenure
                                                               && x.SubType == SubType.newTenure);
             newTenureDetails.Should().NotBeNull();
+            var tenureDate = DateTime.Parse(requestObject.FormData[SoleToJointKeys.TenureStartDate].ToString());
             // oldTenure
             var oldTenure = await _dbFixture.DynamoDbContext.LoadAsync<TenureInformationDb>(process.TargetId).ConfigureAwait(false);
-            oldTenure.EndOfTenureDate.Should().BeCloseTo(DateTime.UtcNow, 3000);
+            oldTenure.EndOfTenureDate.Should().Be(tenureDate);
             // newTenure
             var newTenure = await _dbFixture.DynamoDbContext.LoadAsync<TenureInformationDb>(newTenureDetails.Id).ConfigureAwait(false);
-            newTenure.StartOfTenureDate.Should().BeCloseTo(DateTime.UtcNow, 3000);
+            newTenure.StartOfTenureDate.Should().Be(tenureDate);
             newTenure.Should().BeEquivalentTo(oldTenure, c => c.Excluding(x => x.Id)
                                                                .Excluding(x => x.HouseholdMembers)
                                                                .Excluding(x => x.StartOfTenureDate)

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/SoleToJointSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/SoleToJointSteps.cs
@@ -104,13 +104,14 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             householdMember.PersonTenureType.Should().Be(PersonTenureType.Tenant);
         }
 
-        public async Task ThenTheProcessUpdatedEventIsRaisedWithNewTenureId(ISnsFixture snsFixture, Guid processId, string oldState, string newState)
+        public async Task ThenTheProcessUpdatedEventIsRaisedWithNewTenureIdAndStartDate(ISnsFixture snsFixture, Guid processId, string oldState, string newState)
         {
             Action<string> verifyData = (dataAsString) =>
             {
                 var dataDic = JsonSerializer.Deserialize<Dictionary<string, object>>(dataAsString, _jsonOptions);
                 var stateData = JsonSerializer.Deserialize<Dictionary<string, object>>(dataDic["stateData"].ToString(), _jsonOptions);
                 stateData.Should().ContainKey(SoleToJointKeys.NewTenureId);
+                stateData.Should().ContainKey(SoleToJointKeys.TenureStartDate);
             };
 
             await VerifyProcessUpdatedEventIsRaised(snsFixture, processId, oldState, newState, verifyData).ConfigureAwait(false);

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/Processes/ChangeOfNameTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/Processes/ChangeOfNameTests.cs
@@ -16,15 +16,15 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
     IWant = "to enter the applicants new name",
     SoThat = "I can change the legal name of the applicant in the system")]
     [Collection("AppTest collection")]
-    public class UpdateChangeOfNameProcessTests : IDisposable
+    public class ChangeOfNameTests : IDisposable
     {
         private readonly IDynamoDbFixture _dbFixture;
         private readonly ISnsFixture _snsFixture;
         private readonly PersonFixture _personFixture;
         private readonly ProcessFixture _processFixture;
-        private readonly UpdateChangeOfNameProcessSteps _steps;
+        private readonly ChangeOfNameSteps _steps;
 
-        public UpdateChangeOfNameProcessTests(AwsMockWebApplicationFactory<Startup> appFactory)
+        public ChangeOfNameTests(AwsMockWebApplicationFactory<Startup> appFactory)
         {
             _dbFixture = appFactory.DynamoDbFixture;
             _snsFixture = appFactory.SnsFixture;
@@ -32,7 +32,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
 
             _processFixture = new ProcessFixture(_dbFixture.DynamoDbContext, _snsFixture.SimpleNotificationService);
 
-            _steps = new UpdateChangeOfNameProcessSteps(appFactory.Client, _dbFixture);
+            _steps = new ChangeOfNameSteps(appFactory.Client, _dbFixture);
         }
 
         public void Dispose()

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/Processes/SoleToJointTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/Processes/SoleToJointTests.cs
@@ -621,7 +621,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
                 .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
                 .Then(a => _steps.ThenTheProcessDataIsUpdated(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject))
                     .And(a => _steps.ThenTheProcessStateIsUpdatedToUpdateTenure(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, initialState, _processFixture.IncomingTenantId))
-                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaisedWithNewTenureId(_snsFixture, _processFixture.ProcessId, initialState, SoleToJointStates.TenureUpdated))
+                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaisedWithNewTenureIdAndStartDate(_snsFixture, _processFixture.ProcessId, initialState, SoleToJointStates.TenureUpdated))
                 .BDDfy();
         }
 

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/Processes/SoleToJointTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/Processes/SoleToJointTests.cs
@@ -16,7 +16,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         IWant = "The system to automatically check a tenant and an applicants eligibility for a Sole to Joint application",
         SoThat = "I can more quickly determine if I should continue with the application")]
     [Collection("AppTest collection")]
-    public class UpdateSoleToJointProcessTests : IDisposable
+    public class SoleToJointTests : IDisposable
     {
         private readonly IDynamoDbFixture _dbFixture;
         private readonly ISnsFixture _snsFixture;
@@ -25,9 +25,9 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         private readonly TenureFixture _tenureFixture;
         private readonly IncomeApiAgreementsFixture _agreementsApiFixture;
         private readonly IncomeApiTenanciesFixture _tenanciesApiFixture;
-        private readonly UpdateSoleToJointProcessSteps _steps;
+        private readonly SoleToJointSteps _steps;
 
-        public UpdateSoleToJointProcessTests(AwsMockWebApplicationFactory<Startup> appFactory)
+        public SoleToJointTests(AwsMockWebApplicationFactory<Startup> appFactory)
         {
             _dbFixture = appFactory.DynamoDbFixture;
             _snsFixture = appFactory.SnsFixture;
@@ -37,7 +37,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
             _agreementsApiFixture = new IncomeApiAgreementsFixture();
             _tenanciesApiFixture = new IncomeApiTenanciesFixture();
 
-            _steps = new UpdateSoleToJointProcessSteps(appFactory.Client, _dbFixture);
+            _steps = new SoleToJointSteps(appFactory.Client, _dbFixture);
         }
 
         public void Dispose()
@@ -612,7 +612,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
         [Theory]
         [InlineData(SharedStates.TenureAppointmentScheduled)]
         [InlineData(SharedStates.TenureAppointmentRescheduled)]
-        public void ProcessStateIsUpdatedToProcessCompleted(string initialState)
+        public void ProcessStateIsUpdatedToTenureUpdated(string initialState)
         {
             this.Given(g => _processFixture.GivenASoleToJointProcessExists(initialState))
                     .And(a => _tenureFixture.GivenATenureExistsAndAPersonIsAddedAsAHouseholdMember(_processFixture.Process.TargetId, _processFixture.IncomingTenantId))
@@ -621,7 +621,19 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
                 .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
                 .Then(a => _steps.ThenTheProcessDataIsUpdated(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject))
                     .And(a => _steps.ThenTheProcessStateIsUpdatedToUpdateTenure(_processFixture.UpdateProcessRequest, initialState, _processFixture.IncomingTenantId))
-                    .And(a => _steps.ThenTheProcessCompletedEventIsRaised(_snsFixture, _processFixture.ProcessId, initialState, SoleToJointStates.TenureUpdated))
+                    .And(a => _steps.ThenTheProcessUpdatedEventIsRaisedWithNewTenureId(_snsFixture, _processFixture.ProcessId, initialState, SoleToJointStates.TenureUpdated))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void ProcessStateIsUpdatedToProcessCompleted()
+        {
+            this.Given(g => _processFixture.GivenASoleToJointProcessExists(SoleToJointStates.TenureUpdated))
+                    .And(a => _processFixture.GivenACompleteProcessRequest())
+                .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
+                .Then(a => _steps.ThenTheProcessDataIsUpdated(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject))
+                    .And(a => _steps.ThenTheProcessStateIsUpdatedToProcessCompleted(_processFixture.UpdateProcessRequest, SoleToJointStates.TenureUpdated))
+                    .And(a => _steps.ThenTheProcessCompletedEventIsRaised(_snsFixture, _processFixture.ProcessId, SoleToJointStates.TenureUpdated, SharedStates.ProcessCompleted))
                 .BDDfy();
         }
 

--- a/ProcessesApi.Tests/V1/E2ETests/Stories/Processes/SoleToJointTests.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Stories/Processes/SoleToJointTests.cs
@@ -620,7 +620,7 @@ namespace ProcessesApi.Tests.V1.E2E.Stories
                     .And(a => _processFixture.GivenAUpdateTenureRequest())
                 .When(w => _steps.WhenAnUpdateProcessRequestIsMade(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, 0))
                 .Then(a => _steps.ThenTheProcessDataIsUpdated(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject))
-                    .And(a => _steps.ThenTheProcessStateIsUpdatedToUpdateTenure(_processFixture.UpdateProcessRequest, initialState, _processFixture.IncomingTenantId))
+                    .And(a => _steps.ThenTheProcessStateIsUpdatedToUpdateTenure(_processFixture.UpdateProcessRequest, _processFixture.UpdateProcessRequestObject, initialState, _processFixture.IncomingTenantId))
                     .And(a => _steps.ThenTheProcessUpdatedEventIsRaisedWithNewTenureId(_snsFixture, _processFixture.ProcessId, initialState, SoleToJointStates.TenureUpdated))
                 .BDDfy();
         }

--- a/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
+++ b/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
@@ -825,12 +825,13 @@ namespace ProcessesApi.Tests.V1.Services
         {
             // Arrange
             var process = CreateProcessWithCurrentState(initialState);
-            var formData = new Dictionary<string, object> { { SoleToJointKeys.TenureStartDate, _fixture.Create<DateTime>() } };
+            var startDate = _fixture.Create<DateTime>();
+            var formData = new Dictionary<string, object> { { SoleToJointKeys.TenureStartDate, startDate } };
             var triggerObject = CreateProcessTrigger(process,
                                                      SoleToJointPermittedTriggers.UpdateTenure,
                                                      formData);
             var newTenureId = Guid.NewGuid();
-            _mockDbOperationsHelper.Setup(x => x.UpdateTenures(process, _token, formData)).ReturnsAsync(newTenureId);
+            _mockDbOperationsHelper.Setup(x => x.UpdateTenures(process, _token, formData)).ReturnsAsync((newTenureId, startDate));
 
             // Act
             await _classUnderTest.Process(triggerObject, process, _token).ConfigureAwait(false);

--- a/ProcessesApi/V1/Constants/Shared/SharedPermittedTriggers.cs
+++ b/ProcessesApi/V1/Constants/Shared/SharedPermittedTriggers.cs
@@ -5,6 +5,7 @@ namespace ProcessesApi.V1.Constants
         public const string StartApplication = "StartApplication";
         public const string CancelProcess = "CancelProcess";
         public const string CloseProcess = "CloseProcess";
+        public const string CompleteProcess = "CompleteProcess";
         public const string RequestDocuments = "RequestDocuments";
         public const string RequestDocumentsDes = "RequestDocumentsDes";
         public const string RequestDocumentsAppointment = "RequestDocumentsAppointment";

--- a/ProcessesApi/V1/Constants/SoleToJoint/SoleToJointKeys.cs
+++ b/ProcessesApi/V1/Constants/SoleToJoint/SoleToJointKeys.cs
@@ -114,5 +114,6 @@ namespace ProcessesApi.V1.Constants.SoleToJoint
         #endregion
 
         public const string NewTenureId = "newTenureId";
+        public const string TenureStartDate = "tenureStartDate";
     }
 }

--- a/ProcessesApi/V1/Helpers/DbOperationsHelper.cs
+++ b/ProcessesApi/V1/Helpers/DbOperationsHelper.cs
@@ -164,12 +164,12 @@ namespace ProcessesApi.V1.Helpers
 
         #region Update tenures
 
-        private async Task EndExistingTenure(TenureInformation tenure)
+        private async Task EndExistingTenure(TenureInformation tenure, DateTime endDate)
         {
             var request = new EditTenureDetailsRequestObject
             {
                 StartOfTenureDate = tenure.StartOfTenureDate,
-                EndOfTenureDate = DateTime.UtcNow,
+                EndOfTenureDate = endDate,
                 TenureType = tenure.TenureType
             };
 
@@ -181,7 +181,7 @@ namespace ProcessesApi.V1.Helpers
             await _snsGateway.Publish(message, topicArn).ConfigureAwait(false);
         }
 
-        private async Task<TenureInformation> CreateNewTenure(TenureInformation oldTenure, Guid incomingTenantId)
+        private async Task<TenureInformation> CreateNewTenure(TenureInformation oldTenure, Guid incomingTenantId, DateTime startDate)
         {
             var request = new CreateTenureRequestObject()
             {
@@ -193,6 +193,7 @@ namespace ProcessesApi.V1.Helpers
                 LegacyReferences = oldTenure.LegacyReferences.ToList(),
                 Terminated = oldTenure.Terminated,
                 TenureType = oldTenure.TenureType,
+                StartOfTenureDate = startDate,
                 EndOfTenureDate = oldTenure.EndOfTenureDate,
                 Charges = oldTenure.Charges,
                 TenuredAsset = oldTenure.TenuredAsset,
@@ -206,9 +207,8 @@ namespace ProcessesApi.V1.Helpers
             if (oldTenure.IsMutualExchange.HasValue) request.IsMutualExchange = oldTenure.IsMutualExchange.Value;
             if (oldTenure.IsTenanted.HasValue) request.IsTenanted = oldTenure.IsTenanted.Value;
 
-            request.StartOfTenureDate = DateTime.UtcNow;
             var householdMember = request.HouseholdMembers.Find(x => x.Id == incomingTenantId);
-            if (householdMember is null) throw new Exception("Not household member");
+            if (householdMember is null) throw new Exception("Incoming Tenant is not a household member.");
             householdMember.PersonTenureType = PersonTenureType.Tenant;
             householdMember.IsResponsible = true;
 
@@ -242,15 +242,19 @@ namespace ProcessesApi.V1.Helpers
             }
         }
 
-        public async Task<Guid> UpdateTenures(Process process, Token token)
+        public async Task<Guid> UpdateTenures(Process process, Token token, Dictionary<string, object> formData)
         {
             _token = token;
+
+            formData.ValidateKeys(new List<string> { SoleToJointKeys.TenureStartDate });
+            var isDateTime = DateTime.TryParse(formData[SoleToJointKeys.TenureStartDate].ToString(), out var startDate);
+            if (!isDateTime) throw new FormDataFormatException(typeof(DateTime), formData[SoleToJointKeys.TenureStartDate]);
 
             var incomingTenant = process.RelatedEntities.Find(x => x.SubType == SubType.householdMember);
             var existingTenure = await _tenureDbGateway.GetTenureById(process.TargetId).ConfigureAwait(false);
 
-            await EndExistingTenure(existingTenure).ConfigureAwait(false);
-            var newTenure = await CreateNewTenure(existingTenure, incomingTenant.Id).ConfigureAwait(false);
+            await EndExistingTenure(existingTenure, startDate).ConfigureAwait(false);
+            var newTenure = await CreateNewTenure(existingTenure, incomingTenant.Id, startDate).ConfigureAwait(false);
             await UpdatePersonRecords(newTenure).ConfigureAwait(false);
 
             return newTenure.Id;

--- a/ProcessesApi/V1/Helpers/DbOperationsHelper.cs
+++ b/ProcessesApi/V1/Helpers/DbOperationsHelper.cs
@@ -242,7 +242,7 @@ namespace ProcessesApi.V1.Helpers
             }
         }
 
-        public async Task<Guid> UpdateTenures(Process process, Token token, Dictionary<string, object> formData)
+        public async Task<(Guid, DateTime)> UpdateTenures(Process process, Token token, Dictionary<string, object> formData)
         {
             _token = token;
 
@@ -257,7 +257,7 @@ namespace ProcessesApi.V1.Helpers
             var newTenure = await CreateNewTenure(existingTenure, incomingTenant.Id, startDate).ConfigureAwait(false);
             await UpdatePersonRecords(newTenure).ConfigureAwait(false);
 
-            return newTenure.Id;
+            return (newTenure.Id, startDate);
         }
 
         #endregion

--- a/ProcessesApi/V1/Helpers/Interfaces/IDbOperationsHelper.cs
+++ b/ProcessesApi/V1/Helpers/Interfaces/IDbOperationsHelper.cs
@@ -12,7 +12,7 @@ namespace ProcessesApi.V1.Helpers
     {
         Task AddIncomingTenantToRelatedEntities(Dictionary<string, object> requestFormData, Process process);
         Task<bool> CheckAutomatedEligibility(Guid tenureId, Guid proposedTenantId, Guid tenantId);
-        Task<Guid> UpdateTenures(Process process, Token token, Dictionary<string, object> formData);
+        Task<(Guid, DateTime)> UpdateTenures(Process process, Token token, Dictionary<string, object> formData);
         Task UpdatePerson(Process process, Token token);
     }
 }

--- a/ProcessesApi/V1/Helpers/Interfaces/IDbOperationsHelper.cs
+++ b/ProcessesApi/V1/Helpers/Interfaces/IDbOperationsHelper.cs
@@ -12,7 +12,7 @@ namespace ProcessesApi.V1.Helpers
     {
         Task AddIncomingTenantToRelatedEntities(Dictionary<string, object> requestFormData, Process process);
         Task<bool> CheckAutomatedEligibility(Guid tenureId, Guid proposedTenantId, Guid tenantId);
-        Task<Guid> UpdateTenures(Process process, Token token);
+        Task<Guid> UpdateTenures(Process process, Token token, Dictionary<string, object> formData);
         Task UpdatePerson(Process process, Token token);
     }
 }

--- a/ProcessesApi/V1/Helpers/ProcessHelper.cs
+++ b/ProcessesApi/V1/Helpers/ProcessHelper.cs
@@ -51,7 +51,7 @@ namespace ProcessesApi.V1.Helpers
             }
             else
             {
-                throw new FormDataFormatException("boolean", hasNotifiedResidentString);
+                throw new FormDataFormatException(typeof(bool), hasNotifiedResidentString);
             }
         }
 

--- a/ProcessesApi/V1/Services/Exceptions/FormDataFormatException.cs
+++ b/ProcessesApi/V1/Services/Exceptions/FormDataFormatException.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace ProcessesApi.V1.Services.Exceptions
 {
     public class FormDataFormatException : FormDataInvalidException
@@ -6,8 +8,8 @@ namespace ProcessesApi.V1.Services.Exceptions
         {
         }
 
-        public FormDataFormatException(string valueType, object value)
-            : base($"The {valueType} provided ({value.ToString()}) is not in the correct format.")
+        public FormDataFormatException(Type valueType, object value)
+            : base($"The value provided ({value.ToString()}) is not in the correct format. Expected {valueType}.")
         {
         }
     }

--- a/ProcessesApi/V1/Services/SoleToJointService.cs
+++ b/ProcessesApi/V1/Services/SoleToJointService.cs
@@ -188,10 +188,14 @@ namespace ProcessesApi.V1.Services
         private async Task UpdateTenures(Stateless.StateMachine<string, string>.Transition x)
         {
             var processRequest = x.Parameters[0] as ProcessTrigger;
-            var newTenureId = await _dbOperationsHelper.UpdateTenures(_process, _token, processRequest.FormData).ConfigureAwait(false);
+            (var newTenureId, var tenureStartDate) = await _dbOperationsHelper.UpdateTenures(_process, _token, processRequest.FormData).ConfigureAwait(false);
 
             _process.AddNewTenureToRelatedEntities(newTenureId);
-            _eventData = new Dictionary<string, object> { { SoleToJointKeys.NewTenureId, newTenureId } };
+            _eventData = new Dictionary<string, object>
+            {
+                { SoleToJointKeys.NewTenureId, newTenureId },
+                { SoleToJointKeys.TenureStartDate,  tenureStartDate }
+            };
         }
 
         #endregion

--- a/ProcessesApi/V1/Services/SoleToJointService.cs
+++ b/ProcessesApi/V1/Services/SoleToJointService.cs
@@ -188,7 +188,7 @@ namespace ProcessesApi.V1.Services
         private async Task UpdateTenures(Stateless.StateMachine<string, string>.Transition x)
         {
             var processRequest = x.Parameters[0] as ProcessTrigger;
-            var newTenureId = await _dbOperationsHelper.UpdateTenures(_process, _token).ConfigureAwait(false);
+            var newTenureId = await _dbOperationsHelper.UpdateTenures(_process, _token, processRequest.FormData).ConfigureAwait(false);
 
             _process.AddNewTenureToRelatedEntities(newTenureId);
             _eventData = new Dictionary<string, object> { { SoleToJointKeys.NewTenureId, newTenureId } };


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-3115

## Describe this PR

- Update the last step of STJ to use the tenure start date sent from the FE.
- Add a final 'ProcessCompleted' state after the tenure is updated

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
