### PR TITLE
Bugfix: Make processStarted event contain correct state name

### DIFF
--- a/ProcessesApi/V1/Services/ChangeOfNameService.cs
+++ b/ProcessesApi/V1/Services/ChangeOfNameService.cs
@@ -147,10 +147,10 @@ namespace ProcessesApi.V1.Services
                     .OnEntryAsync(OnProcessCancelled);
 
             _machine.Configure(SharedStates.ApplicationInitialised)
-                    .Permit(SharedPermittedTriggers.StartApplication, ChangeOfNameStates.EnterNewName)
-                    .OnExitAsync(() => PublishProcessStartedEvent(ProcessEventConstants.PROCESS_STARTED_AGAINST_PERSON_EVENT));
+                    .Permit(SharedPermittedTriggers.StartApplication, ChangeOfNameStates.EnterNewName);
 
             _machine.Configure(ChangeOfNameStates.EnterNewName)
+                    .OnEntryAsync(() => PublishProcessStartedEvent(ProcessEventConstants.PROCESS_STARTED_AGAINST_PERSON_EVENT))
                     .Permit(ChangeOfNamePermittedTriggers.EnterNewName, ChangeOfNameStates.NameSubmitted);
 
             _machine.Configure(ChangeOfNameStates.NameSubmitted)

--- a/ProcessesApi/V1/Services/SoleToJointService.cs
+++ b/ProcessesApi/V1/Services/SoleToJointService.cs
@@ -215,10 +215,10 @@ namespace ProcessesApi.V1.Services
                     .OnEntryAsync(OnProcessCancelled);
 
             _machine.Configure(SharedStates.ApplicationInitialised)
-                    .Permit(SharedPermittedTriggers.StartApplication, SoleToJointStates.SelectTenants)
-                    .OnExitAsync(() => PublishProcessStartedEvent(ProcessEventConstants.PROCESS_STARTED_AGAINST_TENURE_EVENT));
+                    .Permit(SharedPermittedTriggers.StartApplication, SoleToJointStates.SelectTenants);
 
             _machine.Configure(SoleToJointStates.SelectTenants)
+                    .OnEntryAsync(() => PublishProcessStartedEvent(ProcessEventConstants.PROCESS_STARTED_AGAINST_TENURE_EVENT))
                     .InternalTransitionAsync(SoleToJointPermittedTriggers.CheckAutomatedEligibility, CheckAutomatedEligibility)
                     .Permit(SoleToJointInternalTriggers.EligibiltyFailed, SoleToJointStates.AutomatedChecksFailed)
                     .Permit(SoleToJointInternalTriggers.EligibiltyPassed, SoleToJointStates.AutomatedChecksPassed)


### PR DESCRIPTION
Currently, the processStarted events do not contain a correct 'currentState' as the event is triggered before the state change is made.

Moved PublishProcessStartedEvent method calls out of OnExitAsync (which happens before a state change) to OnEntryAsync to fix the error.