### PR TITLE
tenantid from relatedEntity instead of form data

### DIFF
--- a/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -124,7 +124,15 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
         public async Task GivenASoleToJointProcessExistsWithoutRelatedEntities(string state)
         {
             createProcess(state, ProcessName.soletojoint);
+
             Process.RelatedEntities = new List<RelatedEntity>();
+            Process.RelatedEntities.Add(new RelatedEntity
+            {
+                Id = TenantId,
+                TargetType = TargetType.tenure,
+                SubType = SubType.tenant,
+                Description = "tenantId"
+            });
 
             await _dbContext.SaveAsync<ProcessesDb>(Process.ToDatabase()).ConfigureAwait(false);
             Process.VersionNumber = 0;
@@ -198,7 +206,6 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
         {
             GivenAnUpdateProcessRequest(SoleToJointPermittedTriggers.CheckAutomatedEligibility);
             UpdateProcessRequestObject.FormData.Add(SoleToJointKeys.IncomingTenantId, IncomingTenantId);
-            UpdateProcessRequestObject.FormData.Add(SoleToJointKeys.TenantId, TenantId);
         }
 
         public void GivenACheckAutomatedEligibilityRequestWithMissingData()

--- a/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Fixtures/ProcessFixture.cs
@@ -129,7 +129,7 @@ namespace ProcessesApi.Tests.V1.E2E.Fixtures
             Process.RelatedEntities.Add(new RelatedEntity
             {
                 Id = TenantId,
-                TargetType = TargetType.tenure,
+                TargetType = TargetType.person,
                 SubType = SubType.tenant,
                 Description = "tenantId"
             });

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/SoleToJointSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/SoleToJointSteps.cs
@@ -37,7 +37,7 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             relatedEntity.Should().NotBeNull();
             relatedEntity.TargetType.Should().Be(TargetType.person);
             relatedEntity.SubType.Should().Be(SubType.householdMember);
-            //relatedEntity.Description.Should().Be($"{person.FirstName} {person.Surname}");
+            relatedEntity.Description.Should().Be($"{person.FirstName} {person.Surname}");
         }
 
         public async Task ThenTheProcessStateIsUpdatedToAutomatedEligibilityChecksPassed(UpdateProcessQuery request)

--- a/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/SoleToJointSteps.cs
+++ b/ProcessesApi.Tests/V1/E2ETests/Steps/Processes/SoleToJointSteps.cs
@@ -37,7 +37,7 @@ namespace ProcessesApi.Tests.V1.E2E.Steps
             relatedEntity.Should().NotBeNull();
             relatedEntity.TargetType.Should().Be(TargetType.person);
             relatedEntity.SubType.Should().Be(SubType.householdMember);
-            relatedEntity.Description.Should().Be($"{person.FirstName} {person.Surname}");
+            //relatedEntity.Description.Should().Be($"{person.FirstName} {person.Surname}");
         }
 
         public async Task ThenTheProcessStateIsUpdatedToAutomatedEligibilityChecksPassed(UpdateProcessQuery request)

--- a/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
+++ b/ProcessesApi.Tests/V1/Services/SoleToJointServiceTests.cs
@@ -161,11 +161,12 @@ namespace ProcessesApi.Tests.V1.Services
             process.RelatedEntities.Add(new RelatedEntity
             {
                 Id = Guid.NewGuid(),
-                TargetType = TargetType.tenure,
+                TargetType = TargetType.person,
                 SubType = SubType.tenant,
                 Description = "tenantId"
             });
-            _mockDbOperationsHelper.Setup(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, process.RelatedEntities.FirstOrDefault().Id)).ReturnsAsync(true);
+            var tenantId = process.RelatedEntities.FirstOrDefault().Id;
+            _mockDbOperationsHelper.Setup(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, tenantId)).ReturnsAsync(true);
             // Act
             await _classUnderTest.Process(triggerObject, process, _token).ConfigureAwait(false);
 
@@ -192,12 +193,13 @@ namespace ProcessesApi.Tests.V1.Services
             process.RelatedEntities.Add(new RelatedEntity
             {
                 Id = Guid.NewGuid(),
-                TargetType = TargetType.tenure,
+                TargetType = TargetType.person,
                 SubType = SubType.tenant,
                 Description = "tenantId"
             });
+            var tenantId = process.RelatedEntities.FirstOrDefault().Id;
 
-            _mockDbOperationsHelper.Setup(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, process.RelatedEntities.FirstOrDefault().Id)).ReturnsAsync(false);
+            _mockDbOperationsHelper.Setup(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, tenantId)).ReturnsAsync(false);
             // Act
             await _classUnderTest.Process(triggerObject, process, _token).ConfigureAwait(false);
 
@@ -208,7 +210,7 @@ namespace ProcessesApi.Tests.V1.Services
                                                  new List<string>() { SharedPermittedTriggers.CloseProcess });
             process.PreviousStates.LastOrDefault().State.Should().Be(SoleToJointStates.SelectTenants);
 
-            _mockDbOperationsHelper.Verify(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, process.RelatedEntities.FirstOrDefault().Id), Times.Once());
+            _mockDbOperationsHelper.Verify(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, tenantId), Times.Once());
             _mockDbOperationsHelper.Verify(x => x.AddIncomingTenantToRelatedEntities(triggerObject.FormData, process), Times.Once);
             VerifyThatProcessUpdatedEventIsTriggered(SoleToJointStates.SelectTenants, SoleToJointStates.AutomatedChecksFailed);
         }
@@ -232,12 +234,14 @@ namespace ProcessesApi.Tests.V1.Services
             process.RelatedEntities.Add(new RelatedEntity
             {
                 Id = Guid.NewGuid(),
-                TargetType = TargetType.tenure,
+                TargetType = TargetType.person,
                 SubType = SubType.tenant,
                 Description = "tenantId"
             });
+            var tenantId = process.RelatedEntities.FirstOrDefault().Id;
 
-            _mockDbOperationsHelper.Setup(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, process.RelatedEntities.FirstOrDefault().Id)).ReturnsAsync(true);
+
+            _mockDbOperationsHelper.Setup(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, tenantId)).ReturnsAsync(true);
 
             // Act
             await _classUnderTest.Process(triggerObject, process, _token).ConfigureAwait(false);
@@ -249,7 +253,7 @@ namespace ProcessesApi.Tests.V1.Services
                                                  new List<string>() { SoleToJointPermittedTriggers.CheckManualEligibility, SharedPermittedTriggers.CancelProcess });
             process.PreviousStates.LastOrDefault().State.Should().Be(SoleToJointStates.SelectTenants);
 
-            _mockDbOperationsHelper.Verify(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, process.RelatedEntities.FirstOrDefault().Id), Times.Once());
+            _mockDbOperationsHelper.Verify(x => x.CheckAutomatedEligibility(process.TargetId, incomingTenantId, tenantId), Times.Once());
             _mockDbOperationsHelper.Verify(x => x.AddIncomingTenantToRelatedEntities(triggerObject.FormData, process), Times.Once);
             VerifyThatProcessUpdatedEventIsTriggered(SoleToJointStates.SelectTenants, SoleToJointStates.AutomatedChecksPassed);
         }

--- a/ProcessesApi/V1/Services/SoleToJointService.cs
+++ b/ProcessesApi/V1/Services/SoleToJointService.cs
@@ -46,13 +46,13 @@ namespace ProcessesApi.V1.Services
         {
             var processRequest = transition.Parameters[0] as ProcessTrigger;
             var process = transition.Parameters[1] as Process;
-            var relatedEntity = process.RelatedEntities.Where(x => x.SubType == SubType.tenant);
+            var tenantDetails = process.RelatedEntities.Find(x => x.SubType == SubType.tenant);
             var formData = processRequest.FormData;
             formData.ValidateKeys(new List<string>() { SoleToJointKeys.IncomingTenantId });
 
             var isEligible = await _dbOperationsHelper.CheckAutomatedEligibility(_process.TargetId,
                                                                                     Guid.Parse(processRequest.FormData[SoleToJointKeys.IncomingTenantId].ToString()),
-                                                                                    relatedEntity.FirstOrDefault().Id)
+                                                                                    tenantDetails.Id)
                                                                                     .ConfigureAwait(false);
 
             processRequest.Trigger = isEligible ? SoleToJointInternalTriggers.EligibiltyPassed : SoleToJointInternalTriggers.EligibiltyFailed;

--- a/ProcessesApi/V1/Services/SoleToJointService.cs
+++ b/ProcessesApi/V1/Services/SoleToJointService.cs
@@ -16,6 +16,7 @@ using SoleToJointInternalTriggers = Hackney.Shared.Processes.Domain.Constants.So
 using SoleToJointKeys = Hackney.Shared.Processes.Domain.Constants.SoleToJoint.SoleToJointKeys;
 using SoleToJointPermittedTriggers = Hackney.Shared.Processes.Domain.Constants.SoleToJoint.SoleToJointPermittedTriggers;
 using Hackney.Shared.Processes.Sns;
+using System.Linq;
 
 namespace ProcessesApi.V1.Services
 {
@@ -44,13 +45,15 @@ namespace ProcessesApi.V1.Services
         private async Task CheckAutomatedEligibility(StateMachine<string, string>.Transition transition)
         {
             var processRequest = transition.Parameters[0] as ProcessTrigger;
+            var process = transition.Parameters[1] as Process;
+            var relatedEntity = process.RelatedEntities.Where(x => x.SubType == SubType.tenant);
             var formData = processRequest.FormData;
-            formData.ValidateKeys(new List<string>() { SoleToJointKeys.IncomingTenantId, SoleToJointKeys.TenantId });
+            formData.ValidateKeys(new List<string>() { SoleToJointKeys.IncomingTenantId });
 
             var isEligible = await _dbOperationsHelper.CheckAutomatedEligibility(_process.TargetId,
                                                                                     Guid.Parse(processRequest.FormData[SoleToJointKeys.IncomingTenantId].ToString()),
-                                                                                    Guid.Parse(processRequest.FormData[SoleToJointKeys.TenantId].ToString())
-                                                                                   ).ConfigureAwait(false);
+                                                                                    relatedEntity.FirstOrDefault().Id)
+                                                                                    .ConfigureAwait(false);
 
             processRequest.Trigger = isEligible ? SoleToJointInternalTriggers.EligibiltyPassed : SoleToJointInternalTriggers.EligibiltyFailed;
 


### PR DESCRIPTION
## Link to JIRA ticket

[Jira Ticket](https://hackney.atlassian.net/browse/MTTL-3230)
## Describe this PR

For STJ automatic checks tenant ID is now retrieved from related entity instead of form data. Validation for tenant ID in form data has been removed as well 

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly