### PR TITLE
Bump JWT core to 1.87.0 for Cognito support.

### DIFF
--- a/ProcessesApi/ProcessesApi.csproj
+++ b/ProcessesApi/ProcessesApi.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.49.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />


### PR DESCRIPTION
# What:
 - Update the `Hackney.Core.JWT` package multiple versions up _(1.49 -> 1.64 -> 1.65 -> 1.66 -> 1.72 -> 1.84 -> 1.87)_.

# Why:
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.

# Notes:
 - This seems like a big jump, but it's not as bad as it seems. Due to poor releases labelling, it's extremely difficult to tell what version introduces what changes. **However!** I've pulled down the `1.49` version of the `JWT` package and inspected its classes, interfaces, and implementations via `ICSharpCode.Decompiler`. It would seem that the only notable difference _(except for my 1.87 release linked below)_ is a change of `Nbf`, `Exp`, `Iat` `Token` class fields data types from `int` to `long` _(see [code](https://github.com/LBHackney-IT/lbh-core/pull/41/changes#diff-b513954bdda66cd2f315a53857acc854be00169edf11f15d4a62a0174bb9365dR13-R17))_. This won't cause any backwards compatibility issues within any of the APIs because 1) they never check those fields, and 2) it's a transition to double length, so the numbers being parsed get more breathing room, not less.
 - What changes does latest JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.
 - **These changes do not require immediate deployment**, they merely need to be present within the repo's main branch. This is so those changes would already be there for when anyone would introduce new changes attempting to access Google groups from the token. Without this JWT version bump, any attempted access of Groups within the token would make the API wouldn't fall over.