### PR TITLE
Release #158, #159, and #160 to staging.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,8 @@ jobs:
   build-and-test:
     executor: docker-python
     steps:
-      - checkout
+      - checkout:
+          method: full
       - setup_remote_docker
       - sonarcloud/scan
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,9 @@ commands:
       environment:
         type: string
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "SHA256:rPzp7kChj9Z72jls470HfO0YvieTbdUiB+y8hlxJN8c"
       - *attach_workspace
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ commands:
       environment:
         type: string
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "SHA256:rPzp7kChj9Z72jls470HfO0YvieTbdUiB+y8hlxJN8c"
       - *attach_workspace
       - checkout
       - run:

--- a/ProcessesApi/ProcessesApi.csproj
+++ b/ProcessesApi/ProcessesApi.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.70.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.49.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />

--- a/ProcessesApi/serverless.yml
+++ b/ProcessesApi/serverless.yml
@@ -230,7 +230,7 @@ resources:
           DurationInSeconds: 0
 custom:
   authorizerArns:
-    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   safeguards:


### PR DESCRIPTION
# What:
 - Release #158 _(only affects dev)_.
 - Release #159 _(pipeline fix)_.
 - Release #160 _(release target)_.

# Why:
 - Preparation for the release of cognito flow to staging. Need to ensure all of the APIs are using the latest JWT Nuget package version for both token schema support.